### PR TITLE
feat: Phase 6実装 — スプライト・ウィンドウ・DMA・ジョイパッド・カートリッジ/MBC1

### DIFF
--- a/src/cartridge.rs
+++ b/src/cartridge.rs
@@ -1,0 +1,398 @@
+// src/cartridge.rs
+// GameBoy カートリッジ・MBCシステム
+//
+// カートリッジヘッダ (0x0100-0x014F):
+//   0x0100-0x0103: エントリポイント
+//   0x0104-0x0133: Nintendoロゴ
+//   0x0134-0x0143: タイトル
+//   0x0147: カートリッジタイプ (MBC種別)
+//   0x0148: ROMサイズ
+//   0x0149: RAMサイズ
+//
+// MBC種別:
+//   0x00: ROM ONLY (MBCなし)
+//   0x01: MBC1
+//   0x02: MBC1+RAM
+//   0x03: MBC1+RAM+BATTERY
+
+/// カートリッジタイプ
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum CartridgeType {
+    RomOnly,
+    Mbc1,
+    Mbc1Ram,
+    Mbc1RamBattery,
+    Unknown(u8),
+}
+
+impl CartridgeType {
+    fn from_byte(byte: u8) -> Self {
+        match byte {
+            0x00 => CartridgeType::RomOnly,
+            0x01 => CartridgeType::Mbc1,
+            0x02 => CartridgeType::Mbc1Ram,
+            0x03 => CartridgeType::Mbc1RamBattery,
+            other => CartridgeType::Unknown(other),
+        }
+    }
+
+    fn has_mbc1(&self) -> bool {
+        matches!(self, CartridgeType::Mbc1 | CartridgeType::Mbc1Ram | CartridgeType::Mbc1RamBattery)
+    }
+
+    fn has_ram(&self) -> bool {
+        matches!(self, CartridgeType::Mbc1Ram | CartridgeType::Mbc1RamBattery)
+    }
+}
+
+/// ROMサイズ (バンク数)
+fn rom_banks_from_byte(byte: u8) -> usize {
+    match byte {
+        0x00 => 2,   // 32KB
+        0x01 => 4,   // 64KB
+        0x02 => 8,   // 128KB
+        0x03 => 16,  // 256KB
+        0x04 => 32,  // 512KB
+        0x05 => 64,  // 1MB
+        0x06 => 128, // 2MB
+        0x07 => 256, // 4MB
+        0x08 => 512, // 8MB
+        _ => 2,
+    }
+}
+
+/// RAMサイズ (バイト数)
+fn ram_size_from_byte(byte: u8) -> usize {
+    match byte {
+        0x00 => 0,
+        0x01 => 2 * 1024,    // 2KB (未使用だが定義)
+        0x02 => 8 * 1024,    // 8KB
+        0x03 => 32 * 1024,   // 32KB (4バンク)
+        0x04 => 128 * 1024,  // 128KB (16バンク)
+        0x05 => 64 * 1024,   // 64KB (8バンク)
+        _ => 0,
+    }
+}
+
+/// カートリッジヘッダ情報
+#[derive(Debug)]
+pub struct CartridgeHeader {
+    pub title: String,
+    pub cartridge_type: CartridgeType,
+    pub rom_banks: usize,
+    pub ram_size: usize,
+}
+
+/// MBC1バンキングモード
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum Mbc1Mode {
+    Rom,  // モード0: ROMバンキング (デフォルト)
+    Ram,  // モード1: RAM バンキング
+}
+
+/// カートリッジ
+pub struct Cartridge {
+    /// ROMデータ
+    rom: Vec<u8>,
+    /// 外部RAM
+    ram: Vec<u8>,
+    /// ヘッダ情報
+    pub header: CartridgeHeader,
+
+    // MBC1レジスタ
+    /// RAM有効フラグ
+    ram_enabled: bool,
+    /// ROMバンク番号 (下位5bit)
+    rom_bank: u8,
+    /// RAM バンク番号 / ROMバンク上位2bit
+    ram_bank: u8,
+    /// バンキングモード
+    banking_mode: Mbc1Mode,
+}
+
+impl Cartridge {
+    /// ROMデータからカートリッジを作成
+    pub fn new(rom_data: Vec<u8>) -> Result<Self, String> {
+        if rom_data.len() < 0x150 {
+            return Err("ROMデータが小さすぎます（ヘッダが不足）".to_string());
+        }
+
+        let header = Self::parse_header(&rom_data);
+        let ram_size = header.ram_size;
+
+        // MBC1+RAMの場合、最低8KBのRAMを確保
+        let actual_ram_size = if header.cartridge_type.has_ram() && ram_size == 0 {
+            8 * 1024
+        } else {
+            ram_size
+        };
+
+        Ok(Self {
+            rom: rom_data,
+            ram: vec![0; actual_ram_size],
+            header,
+            ram_enabled: false,
+            rom_bank: 1,
+            ram_bank: 0,
+            banking_mode: Mbc1Mode::Rom,
+        })
+    }
+
+    /// ROM ONLYカートリッジを作成（テスト用）
+    pub fn new_rom_only(rom_data: Vec<u8>) -> Self {
+        let len = rom_data.len();
+        let mut padded = rom_data;
+        if len < 0x8000 {
+            padded.resize(0x8000, 0xFF);
+        }
+
+        Self {
+            rom: padded,
+            ram: vec![0; 0],
+            header: CartridgeHeader {
+                title: "TEST".to_string(),
+                cartridge_type: CartridgeType::RomOnly,
+                rom_banks: 2,
+                ram_size: 0,
+            },
+            ram_enabled: false,
+            rom_bank: 1,
+            ram_bank: 0,
+            banking_mode: Mbc1Mode::Rom,
+        }
+    }
+
+    /// ヘッダを解析
+    fn parse_header(rom: &[u8]) -> CartridgeHeader {
+        // タイトル (0x0134-0x0143)
+        let title_bytes = &rom[0x0134..=0x0143];
+        let title = title_bytes.iter()
+            .take_while(|&&b| b != 0)
+            .map(|&b| b as char)
+            .collect::<String>();
+
+        let cartridge_type = CartridgeType::from_byte(rom[0x0147]);
+        let rom_banks = rom_banks_from_byte(rom[0x0148]);
+        let ram_size = ram_size_from_byte(rom[0x0149]);
+
+        CartridgeHeader {
+            title,
+            cartridge_type,
+            rom_banks,
+            ram_size,
+        }
+    }
+
+    /// ROM領域の読み取り (0x0000-0x7FFF)
+    pub fn read_rom(&self, addr: u16) -> u8 {
+        match addr {
+            // Bank 0 (0x0000-0x3FFF) — 常にバンク0
+            0x0000..=0x3FFF => {
+                if self.header.cartridge_type == CartridgeType::RomOnly {
+                    self.rom.get(addr as usize).copied().unwrap_or(0xFF)
+                } else {
+                    // MBC1 モード1ではBank 0の代わりに0x20/0x40/0x60バンク
+                    let bank = if self.banking_mode == Mbc1Mode::Ram {
+                        (self.ram_bank as usize) << 5
+                    } else {
+                        0
+                    };
+                    let offset = bank * 0x4000 + addr as usize;
+                    self.rom.get(offset).copied().unwrap_or(0xFF)
+                }
+            }
+            // Bank N (0x4000-0x7FFF)
+            0x4000..=0x7FFF => {
+                if self.header.cartridge_type == CartridgeType::RomOnly {
+                    self.rom.get(addr as usize).copied().unwrap_or(0xFF)
+                } else {
+                    let bank = self.effective_rom_bank();
+                    let offset = bank * 0x4000 + (addr as usize - 0x4000);
+                    self.rom.get(offset).copied().unwrap_or(0xFF)
+                }
+            }
+            _ => 0xFF,
+        }
+    }
+
+    /// ROM領域への書き込み (MBCレジスタ操作)
+    pub fn write_rom(&mut self, addr: u16, value: u8) {
+        if !self.header.cartridge_type.has_mbc1() {
+            return; // ROM ONLYは書き込み不可
+        }
+
+        match addr {
+            // RAM Enable (0x0000-0x1FFF)
+            0x0000..=0x1FFF => {
+                self.ram_enabled = (value & 0x0F) == 0x0A;
+            }
+            // ROM Bank Number (0x2000-0x3FFF) — 下位5bit
+            0x2000..=0x3FFF => {
+                let bank = value & 0x1F;
+                self.rom_bank = if bank == 0 { 1 } else { bank };
+            }
+            // RAM Bank Number / Upper ROM Bank (0x4000-0x5FFF)
+            0x4000..=0x5FFF => {
+                self.ram_bank = value & 0x03;
+            }
+            // Banking Mode (0x6000-0x7FFF)
+            0x6000..=0x7FFF => {
+                self.banking_mode = if value & 0x01 == 0 {
+                    Mbc1Mode::Rom
+                } else {
+                    Mbc1Mode::Ram
+                };
+            }
+            _ => {}
+        }
+    }
+
+    /// 外部RAM読み取り (0xA000-0xBFFF)
+    pub fn read_ram(&self, addr: u16) -> u8 {
+        if !self.ram_enabled || self.ram.is_empty() {
+            return 0xFF;
+        }
+
+        let bank = if self.banking_mode == Mbc1Mode::Ram {
+            self.ram_bank as usize
+        } else {
+            0
+        };
+        let offset = bank * 0x2000 + (addr as usize - 0xA000);
+        self.ram.get(offset).copied().unwrap_or(0xFF)
+    }
+
+    /// 外部RAM書き込み (0xA000-0xBFFF)
+    pub fn write_ram(&mut self, addr: u16, value: u8) {
+        if !self.ram_enabled || self.ram.is_empty() {
+            return;
+        }
+
+        let bank = if self.banking_mode == Mbc1Mode::Ram {
+            self.ram_bank as usize
+        } else {
+            0
+        };
+        let offset = bank * 0x2000 + (addr as usize - 0xA000);
+        if offset < self.ram.len() {
+            self.ram[offset] = value;
+        }
+    }
+
+    /// 実効ROMバンク番号を計算
+    fn effective_rom_bank(&self) -> usize {
+        let bank = (self.ram_bank as usize) << 5 | (self.rom_bank as usize);
+        bank % self.header.rom_banks
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn create_test_rom(size: usize, cart_type: u8) -> Vec<u8> {
+        let mut rom = vec![0u8; size];
+        // エントリポイント
+        rom[0x0100] = 0x00; // NOP
+        // タイトル
+        let title = b"TEST";
+        rom[0x0134..0x0134 + title.len()].copy_from_slice(title);
+        // カートリッジタイプ
+        rom[0x0147] = cart_type;
+        // ROMサイズ (32KB = 0x00)
+        rom[0x0148] = 0x00;
+        // RAMサイズ
+        rom[0x0149] = 0x00;
+        rom
+    }
+
+    #[test]
+    fn test_rom_only_cartridge() {
+        let mut rom = create_test_rom(0x8000, 0x00);
+        rom[0x0000] = 0x31; // テスト用データ
+        rom[0x7FFF] = 0x42;
+
+        let cart = Cartridge::new(rom).unwrap();
+        assert_eq!(cart.header.cartridge_type, CartridgeType::RomOnly);
+        assert_eq!(cart.read_rom(0x0000), 0x31);
+        assert_eq!(cart.read_rom(0x7FFF), 0x42);
+    }
+
+    #[test]
+    fn test_cartridge_header_parse() {
+        let rom = create_test_rom(0x8000, 0x01);
+        let cart = Cartridge::new(rom).unwrap();
+        assert_eq!(cart.header.title, "TEST");
+        assert_eq!(cart.header.cartridge_type, CartridgeType::Mbc1);
+        assert_eq!(cart.header.rom_banks, 2);
+    }
+
+    #[test]
+    fn test_mbc1_rom_bank_switching() {
+        // 64KB ROM (4バンク)
+        let mut rom = create_test_rom(0x10000, 0x01);
+        rom[0x0148] = 0x01; // 64KB
+
+        // 各バンクの先頭にテスト用データ配置
+        rom[0x4000] = 0x11; // Bank 1
+        rom[0x8000] = 0x22; // Bank 2
+        rom[0xC000] = 0x33; // Bank 3
+
+        let mut cart = Cartridge::new(rom).unwrap();
+
+        // デフォルトはバンク1
+        assert_eq!(cart.read_rom(0x4000), 0x11);
+
+        // バンク2に切り替え
+        cart.write_rom(0x2000, 0x02);
+        assert_eq!(cart.read_rom(0x4000), 0x22);
+
+        // バンク3に切り替え
+        cart.write_rom(0x2000, 0x03);
+        assert_eq!(cart.read_rom(0x4000), 0x33);
+    }
+
+    #[test]
+    fn test_mbc1_bank0_redirect() {
+        // バンク0への書き込みは自動的にバンク1にリダイレクト
+        let rom = create_test_rom(0x8000, 0x01);
+        let mut cart = Cartridge::new(rom).unwrap();
+        cart.write_rom(0x2000, 0x00); // バンク0を指定
+        assert_eq!(cart.rom_bank, 1); // バンク1にリダイレクト
+    }
+
+    #[test]
+    fn test_mbc1_ram() {
+        let mut rom = create_test_rom(0x8000, 0x02); // MBC1+RAM
+        rom[0x0149] = 0x02; // 8KB RAM
+
+        let mut cart = Cartridge::new(rom).unwrap();
+
+        // RAMが無効な場合は0xFFを返す
+        assert_eq!(cart.read_ram(0xA000), 0xFF);
+
+        // RAM有効化
+        cart.write_rom(0x0000, 0x0A);
+        cart.write_ram(0xA000, 0x42);
+        assert_eq!(cart.read_ram(0xA000), 0x42);
+
+        // RAM無効化
+        cart.write_rom(0x0000, 0x00);
+        assert_eq!(cart.read_ram(0xA000), 0xFF);
+    }
+
+    #[test]
+    fn test_rom_too_small() {
+        let rom = vec![0u8; 0x100]; // ヘッダが不足
+        assert!(Cartridge::new(rom).is_err());
+    }
+
+    #[test]
+    fn test_new_rom_only_convenience() {
+        let rom = vec![0x00; 0x100]; // 小さなROM
+        let cart = Cartridge::new_rom_only(rom);
+        assert_eq!(cart.header.cartridge_type, CartridgeType::RomOnly);
+        // 32KBにパディングされている
+        assert_eq!(cart.rom.len(), 0x8000);
+    }
+}

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -1,0 +1,135 @@
+// src/dma.rs
+// GameBoy OAM DMA転送コントローラ
+//
+// DMAレジスタ (0xFF46) に書き込むと、指定アドレスから160バイトをOAMにコピー。
+// 転送元: (value << 8) + 0x00 ～ (value << 8) + 0x9F
+// 転送先: 0xFE00 ～ 0xFE9F (OAM)
+// 転送時間: 160 Mサイクル (640 Tサイクル)
+// 転送中はHRAM以外のメモリアクセスが制限される（簡易実装では即時コピー）
+
+/// DMA転送コントローラ
+pub struct Dma {
+    /// DMA転送アクティブフラグ
+    pub active: bool,
+    /// 転送元ベースアドレス (上位バイト)
+    pub source: u8,
+    /// 転送バイトカウンタ
+    pub byte_counter: u8,
+    /// 残り転送サイクル
+    pub remaining_cycles: u16,
+}
+
+impl Dma {
+    pub fn new() -> Self {
+        Self {
+            active: false,
+            source: 0,
+            byte_counter: 0,
+            remaining_cycles: 0,
+        }
+    }
+
+    /// DMAレジスタへの書き込み（転送開始）
+    pub fn start(&mut self, value: u8) {
+        self.active = true;
+        self.source = value;
+        self.byte_counter = 0;
+        self.remaining_cycles = 640; // 160 Mサイクル = 640 Tサイクル
+    }
+
+    /// DMAレジスタの読み取り
+    pub fn read(&self) -> u8 {
+        self.source
+    }
+
+    /// 転送元アドレスを計算
+    pub fn source_address(&self) -> u16 {
+        (self.source as u16) << 8
+    }
+
+    /// DMA転送が完了したかどうか
+    pub fn is_active(&self) -> bool {
+        self.active
+    }
+
+    /// DMAを1サイクル進める。転送すべきバイトがあれば(src_addr, dst_addr)を返す
+    pub fn tick(&mut self) -> Option<(u16, u16)> {
+        if !self.active {
+            return None;
+        }
+
+        // 4Tサイクルごとに1バイト転送（デクリメント前にチェック）
+        let transfer = if self.remaining_cycles % 4 == 0 && self.byte_counter < 160 {
+            let src = self.source_address() + self.byte_counter as u16;
+            let dst = 0xFE00 + self.byte_counter as u16;
+            self.byte_counter += 1;
+            Some((src, dst))
+        } else {
+            None
+        };
+
+        self.remaining_cycles = self.remaining_cycles.saturating_sub(1);
+
+        if self.byte_counter >= 160 || self.remaining_cycles == 0 {
+            self.active = false;
+        }
+
+        transfer
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_dma_creation() {
+        let dma = Dma::new();
+        assert!(!dma.is_active());
+        assert_eq!(dma.source, 0);
+    }
+
+    #[test]
+    fn test_dma_start() {
+        let mut dma = Dma::new();
+        dma.start(0xC0); // 転送元: 0xC000
+        assert!(dma.is_active());
+        assert_eq!(dma.source_address(), 0xC000);
+        assert_eq!(dma.read(), 0xC0);
+    }
+
+    #[test]
+    fn test_dma_transfer_addresses() {
+        let mut dma = Dma::new();
+        dma.start(0xC0);
+
+        // 最初のティックで転送が発生
+        let result = dma.tick();
+        assert!(result.is_some());
+        let (src, dst) = result.unwrap();
+        assert_eq!(src, 0xC000);
+        assert_eq!(dst, 0xFE00);
+    }
+
+    #[test]
+    fn test_dma_completes() {
+        let mut dma = Dma::new();
+        dma.start(0xC0);
+
+        let mut transfer_count = 0;
+        for _ in 0..700 {
+            if dma.tick().is_some() {
+                transfer_count += 1;
+            }
+        }
+
+        assert_eq!(transfer_count, 160);
+        assert!(!dma.is_active());
+    }
+
+    #[test]
+    fn test_dma_inactive_tick() {
+        let mut dma = Dma::new();
+        assert!(dma.tick().is_none());
+    }
+}

--- a/src/joypad.rs
+++ b/src/joypad.rs
@@ -1,0 +1,227 @@
+// src/joypad.rs
+// GameBoy ジョイパッド入力システム
+//
+// JOYP (0xFF00) レジスタ:
+//   Bit 5 - P15: ボタンキー選択 (0=選択)
+//   Bit 4 - P14: 方向キー選択  (0=選択)
+//   Bit 3 - P13: Down  or Start  (0=押下)
+//   Bit 2 - P12: Up    or Select (0=押下)
+//   Bit 1 - P11: Left  or B      (0=押下)
+//   Bit 0 - P10: Right or A      (0=押下)
+//
+// 読み取り時: 選択されたグループのボタン状態が下位4bitに反映
+// 未選択時は0xF（全ボタン離し）を返す
+
+/// ジョイパッドボタン
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum JoypadButton {
+    // 方向キー (P14)
+    Right,
+    Left,
+    Up,
+    Down,
+    // ボタンキー (P15)
+    A,
+    B,
+    Select,
+    Start,
+}
+
+/// ジョイパッドコントローラ
+pub struct Joypad {
+    /// ボタンキー状態 (bit0=A, bit1=B, bit2=Select, bit3=Start, 0=押下)
+    button_keys: u8,
+    /// 方向キー状態 (bit0=Right, bit1=Left, bit2=Up, bit3=Down, 0=押下)
+    direction_keys: u8,
+    /// 選択レジスタ (bit4=方向キー選択, bit5=ボタンキー選択)
+    select: u8,
+    /// 割り込み要求フラグ
+    pub interrupt_request: bool,
+}
+
+impl Joypad {
+    pub fn new() -> Self {
+        Self {
+            button_keys: 0x0F,    // 全ボタン離し
+            direction_keys: 0x0F, // 全方向キー離し
+            select: 0x30,         // 初期値: 両方未選択
+            interrupt_request: false,
+        }
+    }
+
+    /// JOYPレジスタの読み取り
+    pub fn read(&self) -> u8 {
+        let mut result = self.select | 0xC0; // 上位2bitは常に1
+
+        // P14 (bit4) が0なら方向キー選択
+        if self.select & 0x10 == 0 {
+            result = (result & 0xF0) | (self.direction_keys & 0x0F);
+        }
+        // P15 (bit5) が0ならボタンキー選択
+        if self.select & 0x20 == 0 {
+            result = (result & 0xF0) | (self.button_keys & 0x0F);
+        }
+        // 両方未選択の場合は0x0F（全ボタン離し）
+        if self.select & 0x30 == 0x30 {
+            result |= 0x0F;
+        }
+
+        result
+    }
+
+    /// JOYPレジスタへの書き込み（上位2bitの選択のみ有効）
+    pub fn write(&mut self, value: u8) {
+        self.select = value & 0x30;
+    }
+
+    /// ボタン押下
+    pub fn press(&mut self, button: JoypadButton) {
+        let old_state = self.get_current_input();
+
+        match button {
+            JoypadButton::Right  => self.direction_keys &= !0x01,
+            JoypadButton::Left   => self.direction_keys &= !0x02,
+            JoypadButton::Up     => self.direction_keys &= !0x04,
+            JoypadButton::Down   => self.direction_keys &= !0x08,
+            JoypadButton::A      => self.button_keys &= !0x01,
+            JoypadButton::B      => self.button_keys &= !0x02,
+            JoypadButton::Select => self.button_keys &= !0x04,
+            JoypadButton::Start  => self.button_keys &= !0x08,
+        }
+
+        let new_state = self.get_current_input();
+
+        // High→Low遷移で割り込み要求
+        if old_state & !new_state != 0 {
+            self.interrupt_request = true;
+        }
+    }
+
+    /// ボタン離し
+    pub fn release(&mut self, button: JoypadButton) {
+        match button {
+            JoypadButton::Right  => self.direction_keys |= 0x01,
+            JoypadButton::Left   => self.direction_keys |= 0x02,
+            JoypadButton::Up     => self.direction_keys |= 0x04,
+            JoypadButton::Down   => self.direction_keys |= 0x08,
+            JoypadButton::A      => self.button_keys |= 0x01,
+            JoypadButton::B      => self.button_keys |= 0x02,
+            JoypadButton::Select => self.button_keys |= 0x04,
+            JoypadButton::Start  => self.button_keys |= 0x08,
+        }
+    }
+
+    /// 現在選択されているグループの入力状態を取得
+    fn get_current_input(&self) -> u8 {
+        let mut input = 0x0F;
+        if self.select & 0x10 == 0 {
+            input &= self.direction_keys;
+        }
+        if self.select & 0x20 == 0 {
+            input &= self.button_keys;
+        }
+        input
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_joypad_creation() {
+        let joypad = Joypad::new();
+        // 初期状態: 全ボタン離し、両グループ未選択
+        assert_eq!(joypad.read() & 0x0F, 0x0F);
+    }
+
+    #[test]
+    fn test_direction_key_select() {
+        let mut joypad = Joypad::new();
+
+        // 方向キーグループ選択
+        joypad.write(0x20); // P14=0 (方向キー選択), P15=1
+
+        // 全キー離し状態
+        assert_eq!(joypad.read() & 0x0F, 0x0F);
+
+        // Rightを押下
+        joypad.press(JoypadButton::Right);
+        assert_eq!(joypad.read() & 0x0F, 0x0E); // bit0=0
+
+        // Upも押下
+        joypad.press(JoypadButton::Up);
+        assert_eq!(joypad.read() & 0x0F, 0x0A); // bit0=0, bit2=0
+    }
+
+    #[test]
+    fn test_button_key_select() {
+        let mut joypad = Joypad::new();
+
+        // ボタンキーグループ選択
+        joypad.write(0x10); // P14=1, P15=0 (ボタンキー選択)
+
+        // Aを押下
+        joypad.press(JoypadButton::A);
+        assert_eq!(joypad.read() & 0x0F, 0x0E); // bit0=0
+
+        // Startも押下
+        joypad.press(JoypadButton::Start);
+        assert_eq!(joypad.read() & 0x0F, 0x06); // bit0=0, bit3=0
+    }
+
+    #[test]
+    fn test_button_release() {
+        let mut joypad = Joypad::new();
+        joypad.write(0x20); // 方向キー選択
+
+        joypad.press(JoypadButton::Right);
+        assert_eq!(joypad.read() & 0x01, 0x00);
+
+        joypad.release(JoypadButton::Right);
+        assert_eq!(joypad.read() & 0x01, 0x01);
+    }
+
+    #[test]
+    fn test_group_isolation() {
+        let mut joypad = Joypad::new();
+
+        // ボタンキーAを押下
+        joypad.press(JoypadButton::A);
+
+        // 方向キーグループ選択時にはAの状態が見えない
+        joypad.write(0x20); // 方向キー選択
+        assert_eq!(joypad.read() & 0x0F, 0x0F);
+
+        // ボタンキーグループ選択時にはAが見える
+        joypad.write(0x10); // ボタンキー選択
+        assert_eq!(joypad.read() & 0x0F, 0x0E);
+    }
+
+    #[test]
+    fn test_interrupt_on_press() {
+        let mut joypad = Joypad::new();
+        joypad.write(0x20); // 方向キー選択
+
+        assert!(!joypad.interrupt_request);
+        joypad.press(JoypadButton::Right);
+        assert!(joypad.interrupt_request);
+
+        // フラグクリア後、離しでは割り込みが発生しない
+        joypad.interrupt_request = false;
+        joypad.release(JoypadButton::Right);
+        assert!(!joypad.interrupt_request);
+    }
+
+    #[test]
+    fn test_both_groups_unselected() {
+        let mut joypad = Joypad::new();
+        joypad.write(0x30); // 両方未選択
+
+        joypad.press(JoypadButton::A);
+        joypad.press(JoypadButton::Right);
+
+        // 両グループ未選択時は全ボタン離し状態
+        assert_eq!(joypad.read() & 0x0F, 0x0F);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,9 @@ mod peripherals;     // メモリバス
 mod cpu;             // CPUコンポーネント
 mod ppu;             // PPUコンポーネント
 mod simple_display;  // 簡易ASCII表示
+mod joypad;          // ジョイパッド入力
+mod dma;             // DMA転送コントローラ
+mod cartridge;       // カートリッジ・MBCシステム
 
 #[cfg(feature = "with_sdl")]
 mod lcd;             // LCDディスプレイ

--- a/src/ppu/sprites.rs
+++ b/src/ppu/sprites.rs
@@ -1,0 +1,350 @@
+// src/ppu/sprites.rs
+// スプライト（OAM）描画システム
+//
+// OAMエントリ (4バイト × 40スプライト = 160バイト):
+//   Byte 0: Y座標 (画面Y + 16)
+//   Byte 1: X座標 (画面X + 8)
+//   Byte 2: タイルID
+//   Byte 3: フラグ
+//     Bit 7: BG/ウィンドウより後ろ (0=前, 1=BGカラー1-3の後ろ)
+//     Bit 6: Y反転
+//     Bit 5: X反転
+//     Bit 4: パレット番号 (0=OBP0, 1=OBP1)
+//
+// 制約:
+//   1スキャンラインあたり最大10スプライト
+//   X座標が小さいスプライトが優先（同じ場合はOAMインデックスが小さい方）
+
+use super::vram::Vram;
+use super::registers::PpuRegisters;
+use super::tiles::ColorConverter;
+
+/// OAMスプライトエントリ
+#[derive(Debug, Clone, Copy)]
+pub struct SpriteEntry {
+    pub y: u8,        // Y座標 (画面Y + 16)
+    pub x: u8,        // X座標 (画面X + 8)
+    pub tile_id: u8,  // タイルID
+    pub flags: u8,    // フラグ
+    pub oam_index: u8, // OAMテーブル内のインデックス
+}
+
+impl SpriteEntry {
+    /// OAMデータからスプライトエントリを作成
+    pub fn from_oam(oam: &[u8], index: usize) -> Self {
+        let base = index * 4;
+        Self {
+            y: oam[base],
+            x: oam[base + 1],
+            tile_id: oam[base + 2],
+            flags: oam[base + 3],
+            oam_index: index as u8,
+        }
+    }
+
+    /// 画面上のY座標を取得
+    pub fn screen_y(&self) -> i16 {
+        self.y as i16 - 16
+    }
+
+    /// 画面上のX座標を取得
+    pub fn screen_x(&self) -> i16 {
+        self.x as i16 - 8
+    }
+
+    /// BG/ウィンドウより後ろか
+    pub fn is_behind_bg(&self) -> bool {
+        self.flags & 0x80 != 0
+    }
+
+    /// Y反転
+    pub fn is_y_flipped(&self) -> bool {
+        self.flags & 0x40 != 0
+    }
+
+    /// X反転
+    pub fn is_x_flipped(&self) -> bool {
+        self.flags & 0x20 != 0
+    }
+
+    /// パレット番号 (0=OBP0, 1=OBP1)
+    pub fn palette_number(&self) -> u8 {
+        (self.flags >> 4) & 0x01
+    }
+
+    /// 指定スキャンラインに表示されるか
+    pub fn is_on_scanline(&self, scanline: u8, sprite_height: u8) -> bool {
+        let screen_y = self.screen_y();
+        let ly = scanline as i16;
+        ly >= screen_y && ly < screen_y + sprite_height as i16
+    }
+}
+
+/// スプライトレンダラ
+pub struct SpriteRenderer;
+
+impl SpriteRenderer {
+    /// OAMスキャン: 指定スキャンラインに表示されるスプライトを収集（最大10個）
+    pub fn scan_oam(oam: &[u8; 160], scanline: u8, sprite_height: u8) -> Vec<SpriteEntry> {
+        let mut sprites: Vec<SpriteEntry> = Vec::with_capacity(10);
+
+        for i in 0..40 {
+            let sprite = SpriteEntry::from_oam(oam, i);
+            if sprite.is_on_scanline(scanline, sprite_height) {
+                sprites.push(sprite);
+                if sprites.len() >= 10 {
+                    break; // 1スキャンラインあたり最大10スプライト
+                }
+            }
+        }
+
+        // X座標でソート（小さい方が優先、同じならOAMインデックスが小さい方が優先）
+        sprites.sort_by(|a, b| {
+            a.x.cmp(&b.x).then(a.oam_index.cmp(&b.oam_index))
+        });
+
+        sprites
+    }
+
+    /// スキャンラインにスプライトを描画
+    /// bg_color_ids: BGの色ID配列（BG優先判定用、160ピクセル）
+    /// line_buffer: 出力ラインバッファ (160 * 3 RGB)
+    pub fn render_scanline(
+        oam: &[u8; 160],
+        vram: &Vram,
+        registers: &PpuRegisters,
+        scanline: u8,
+        bg_color_ids: &[u8; 160],
+        line_buffer: &mut [u8],
+    ) {
+        if !registers.is_sprite_enabled() {
+            return;
+        }
+
+        let sprite_height: u8 = if registers.is_sprite_size_16() { 16 } else { 8 };
+        let sprites = Self::scan_oam(oam, scanline, sprite_height);
+
+        // 逆順で描画（低優先度のスプライトから先に描画し、高優先度で上書き）
+        for sprite in sprites.iter().rev() {
+            let screen_x = sprite.screen_x();
+            let screen_y = sprite.screen_y();
+            let line_in_sprite = (scanline as i16 - screen_y) as u8;
+
+            // Y反転の処理
+            let tile_line = if sprite.is_y_flipped() {
+                sprite_height - 1 - line_in_sprite
+            } else {
+                line_in_sprite
+            };
+
+            // 8x16モード時のタイルID調整
+            let tile_id = if sprite_height == 16 {
+                if tile_line < 8 {
+                    sprite.tile_id & 0xFE // 上半分
+                } else {
+                    sprite.tile_id | 0x01 // 下半分
+                }
+            } else {
+                sprite.tile_id
+            };
+
+            let tile_line_in_tile = tile_line % 8;
+
+            // タイルデータ読み出し（スプライトは常に0x8000ベース）
+            let tile_addr = (tile_id as u16) * 16 + (tile_line_in_tile as u16) * 2;
+            let byte1 = vram.read(tile_addr);
+            let byte2 = vram.read(tile_addr + 1);
+
+            // 8ピクセルを描画
+            for pixel_x in 0..8 {
+                let screen_pixel_x = screen_x + pixel_x as i16;
+
+                // 画面外チェック
+                if screen_pixel_x < 0 || screen_pixel_x >= 160 {
+                    continue;
+                }
+                let sx = screen_pixel_x as usize;
+
+                // X反転の処理
+                let bit = if sprite.is_x_flipped() {
+                    pixel_x
+                } else {
+                    7 - pixel_x
+                };
+
+                let pixel_low = (byte1 >> bit) & 1;
+                let pixel_high = (byte2 >> bit) & 1;
+                let color_id = pixel_low | (pixel_high << 1);
+
+                // 色ID 0は透明
+                if color_id == 0 {
+                    continue;
+                }
+
+                // BG優先フラグチェック
+                if sprite.is_behind_bg() && bg_color_ids[sx] != 0 {
+                    continue;
+                }
+
+                // パレット適用
+                let palette_color = if sprite.palette_number() == 0 {
+                    registers.get_obp0_color(color_id)
+                } else {
+                    registers.get_obp1_color(color_id)
+                };
+
+                // RGB変換
+                let (r, g, b) = ColorConverter::dmg_to_rgb888(palette_color);
+                let idx = sx * 3;
+                line_buffer[idx] = r;
+                line_buffer[idx + 1] = g;
+                line_buffer[idx + 2] = b;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sprite_entry_from_oam() {
+        let mut oam = [0u8; 160];
+        // スプライト0: Y=32, X=16, TileID=1, Flags=0x00
+        oam[0] = 32;
+        oam[1] = 16;
+        oam[2] = 1;
+        oam[3] = 0x00;
+
+        let entry = SpriteEntry::from_oam(&oam, 0);
+        assert_eq!(entry.screen_y(), 16);  // 32 - 16
+        assert_eq!(entry.screen_x(), 8);   // 16 - 8
+        assert_eq!(entry.tile_id, 1);
+        assert!(!entry.is_behind_bg());
+        assert!(!entry.is_y_flipped());
+        assert!(!entry.is_x_flipped());
+        assert_eq!(entry.palette_number(), 0);
+    }
+
+    #[test]
+    fn test_sprite_flags() {
+        let mut oam = [0u8; 160];
+        oam[3] = 0xF0; // BG優先=1, Y反転=1, X反転=1, パレット1
+
+        let entry = SpriteEntry::from_oam(&oam, 0);
+        assert!(entry.is_behind_bg());
+        assert!(entry.is_y_flipped());
+        assert!(entry.is_x_flipped());
+        assert_eq!(entry.palette_number(), 1);
+    }
+
+    #[test]
+    fn test_sprite_on_scanline_8x8() {
+        let mut oam = [0u8; 160];
+        oam[0] = 24; // screen_y = 8
+
+        let entry = SpriteEntry::from_oam(&oam, 0);
+        assert!(!entry.is_on_scanline(7, 8));  // 7 < 8
+        assert!(entry.is_on_scanline(8, 8));   // 8 >= 8 && 8 < 16
+        assert!(entry.is_on_scanline(15, 8));  // 15 >= 8 && 15 < 16
+        assert!(!entry.is_on_scanline(16, 8)); // 16 >= 16
+    }
+
+    #[test]
+    fn test_sprite_on_scanline_8x16() {
+        let mut oam = [0u8; 160];
+        oam[0] = 24; // screen_y = 8
+
+        let entry = SpriteEntry::from_oam(&oam, 0);
+        assert!(entry.is_on_scanline(8, 16));  // 8 >= 8 && 8 < 24
+        assert!(entry.is_on_scanline(23, 16)); // 23 >= 8 && 23 < 24
+        assert!(!entry.is_on_scanline(24, 16));
+    }
+
+    #[test]
+    fn test_oam_scan_max_10() {
+        let mut oam = [0u8; 160];
+        // 15個のスプライトをスキャンライン0に配置
+        for i in 0..15 {
+            oam[i * 4] = 16;     // screen_y = 0
+            oam[i * 4 + 1] = (i as u8 + 1) * 8 + 8;
+        }
+
+        let sprites = SpriteRenderer::scan_oam(&oam, 0, 8);
+        assert_eq!(sprites.len(), 10); // 最大10個
+    }
+
+    #[test]
+    fn test_oam_scan_sorting() {
+        let mut oam = [0u8; 160];
+        // スプライト0: X=40
+        oam[0] = 16; oam[1] = 40;
+        // スプライト1: X=20
+        oam[4] = 16; oam[5] = 20;
+        // スプライト2: X=30
+        oam[8] = 16; oam[9] = 30;
+
+        let sprites = SpriteRenderer::scan_oam(&oam, 0, 8);
+        assert_eq!(sprites.len(), 3);
+        assert_eq!(sprites[0].x, 20); // X座標順
+        assert_eq!(sprites[1].x, 30);
+        assert_eq!(sprites[2].x, 40);
+    }
+
+    #[test]
+    fn test_sprite_transparent_color() {
+        let mut oam = [0u8; 160];
+        let vram = Vram::new(); // 全て0 → 色ID=0（透明）
+        let mut registers = PpuRegisters::new();
+        registers.lcdc = 0x93; // スプライト有効
+        registers.obp0 = 0xE4;
+
+        // スプライトをスキャンライン0に配置
+        oam[0] = 16; // screen_y = 0
+        oam[1] = 8;  // screen_x = 0
+        oam[2] = 0;  // tile_id = 0
+
+        let bg_colors = [0u8; 160];
+        let mut line_buffer = [0u8; 160 * 3];
+
+        // 全タイルデータが0なので、色IDは全て0（透明）で描画されない
+        SpriteRenderer::render_scanline(
+            &oam, &vram, &registers, 0, &bg_colors, &mut line_buffer,
+        );
+
+        // 透明なので変更されない
+        assert_eq!(line_buffer[0], 0);
+    }
+
+    #[test]
+    fn test_sprite_rendering_basic() {
+        let mut oam = [0u8; 160];
+        let mut vram = Vram::new();
+        let mut registers = PpuRegisters::new();
+        registers.lcdc = 0x93; // スプライト有効
+        registers.obp0 = 0xE4; // パレット: 3,2,1,0
+
+        // スプライトをスキャンライン0に配置
+        oam[0] = 16; // screen_y = 0
+        oam[1] = 8;  // screen_x = 0
+        oam[2] = 0;  // tile_id = 0
+
+        // タイル0のデータ: 最初のライン = 0xFF, 0x00 → 色ID 1（全ピクセル）
+        vram.write(0x0000, 0xFF);
+        vram.write(0x0001, 0x00);
+
+        let bg_colors = [0u8; 160];
+        let mut line_buffer = [0u8; 160 * 3];
+
+        SpriteRenderer::render_scanline(
+            &oam, &vram, &registers, 0, &bg_colors, &mut line_buffer,
+        );
+
+        // 色ID=1、OBP0=0xE4 → パレット色1
+        let (r, g, b) = ColorConverter::dmg_to_rgb888(1);
+        assert_eq!(line_buffer[0], r);
+        assert_eq!(line_buffer[1], g);
+        assert_eq!(line_buffer[2], b);
+    }
+}


### PR DESCRIPTION
Phase 6で以下の機能を追加:

- ジョイパッド入力システム (joypad.rs): 方向キー/ボタンキーの2グループ選択式、
  High→Low遷移による割り込み要求、Peripherals統合
- OAM DMA転送コントローラ (dma.rs): 0xFF46書き込みで160バイト転送開始、
  4Tサイクルごとに1バイト転送、Peripherals.tick()で自動駆動
- カートリッジ・MBCシステム (cartridge.rs): ROM ONLY/MBC1/MBC1+RAM/MBC1+RAM+BATTERY対応、
  ROMバンク切り替え（5bit）、RAMバンク切り替え（2bit）、バンキングモード
- スプライト描画 (ppu/sprites.rs): OAMスキャン（最大10スプライト/ライン）、
  8x8/8x16モード、X/Y反転、BG優先度、OBP0/OBP1パレット、X座標ソート
- ウィンドウレイヤー描画 (ppu/mod.rs): WY/WXレジスタ対応、内部ラインカウンタ、
  BGと同じタイルデータモード使用
- PPUレジスタ拡張: OBP0/OBP1（スプライトパレット）、WY/WX（ウィンドウ位置）
- Peripherals統合: 全新規コンポーネントのメモリバス統合、I/Oレジスタルーティング更新

テスト: 93 → 127（+34テスト追加、全パス）

https://claude.ai/code/session_011NuQKr15oeCYWJ7rdkQZ5p