### PR TITLE
feat: Phase 7実装 — APU(音声4ch)・シリアル通信・MBC2/MBC3(RTC)/MBC5

### DIFF
--- a/src/apu/mod.rs
+++ b/src/apu/mod.rs
@@ -1,0 +1,565 @@
+// src/apu/mod.rs
+// GameBoy APU (Audio Processing Unit) コア
+//
+// 4チャンネル構成:
+//   Channel 1: パルス波 + 周波数スイープ (NR10-NR14)
+//   Channel 2: パルス波 (NR21-NR24)
+//   Channel 3: ウェーブテーブル (NR30-NR34 + Wave RAM)
+//   Channel 4: ノイズ (NR41-NR44)
+//
+// マスター制御:
+//   NR50 (0xFF24): マスター音量/VINパニング
+//   NR51 (0xFF25): 音声出力選択（各チャンネルの左右パニング）
+//   NR52 (0xFF26): APU電源・チャンネル状態
+//
+// フレームシーケンサ (512Hz):
+//   Step 0: 長さカウンタ
+//   Step 1: (なし)
+//   Step 2: 長さカウンタ、スイープ
+//   Step 3: (なし)
+//   Step 4: 長さカウンタ
+//   Step 5: (なし)
+//   Step 6: 長さカウンタ、スイープ
+//   Step 7: エンベロープ
+
+pub mod pulse;
+pub mod wave;
+pub mod noise;
+
+use pulse::PulseChannel;
+use wave::WaveChannel;
+use noise::NoiseChannel;
+use crate::memory_map::io_registers::*;
+
+/// フレームシーケンサの周期 (CPUサイクル: 4,194,304 / 512 = 8192)
+const FRAME_SEQUENCER_PERIOD: u16 = 8192;
+
+/// APU (Audio Processing Unit)
+pub struct Apu {
+    /// Channel 1: パルス + スイープ
+    pub channel1: PulseChannel,
+    /// Channel 2: パルス
+    pub channel2: PulseChannel,
+    /// Channel 3: ウェーブ
+    pub channel3: WaveChannel,
+    /// Channel 4: ノイズ
+    pub channel4: NoiseChannel,
+
+    // NR50: マスター音量
+    /// VIN→左出力 (未使用だがレジスタとして保持)
+    pub vin_left: bool,
+    /// 左ボリューム (0-7)
+    pub left_volume: u8,
+    /// VIN→右出力
+    pub vin_right: bool,
+    /// 右ボリューム (0-7)
+    pub right_volume: u8,
+
+    // NR51: パニング
+    /// 各チャンネルの左右出力設定
+    pub panning: u8,
+
+    // NR52: APU電源
+    /// APU有効フラグ
+    pub power: bool,
+
+    /// フレームシーケンサタイマー
+    frame_sequencer_timer: u16,
+    /// フレームシーケンサステップ (0-7)
+    frame_sequencer_step: u8,
+
+    /// オーディオサンプルバッファ（左右インターリーブ、-1.0〜1.0）
+    pub sample_buffer: Vec<f32>,
+    /// サンプル生成用ダウンサンプルカウンタ
+    downsample_counter: u32,
+    /// サンプリングレート (デフォルト: 44100Hz)
+    pub sample_rate: u32,
+}
+
+impl Apu {
+    pub fn new() -> Self {
+        Self {
+            channel1: PulseChannel::new(true),
+            channel2: PulseChannel::new(false),
+            channel3: WaveChannel::new(),
+            channel4: NoiseChannel::new(),
+            vin_left: false,
+            left_volume: 0,
+            vin_right: false,
+            right_volume: 0,
+            panning: 0x00,
+            power: false,
+            frame_sequencer_timer: FRAME_SEQUENCER_PERIOD,
+            frame_sequencer_step: 0,
+            sample_buffer: Vec::new(),
+            downsample_counter: 0,
+            sample_rate: 44100,
+        }
+    }
+
+    /// APUを1 CPUサイクル進める
+    pub fn tick(&mut self) {
+        if !self.power {
+            return;
+        }
+
+        // 各チャンネルの周波数タイマーを進める
+        self.channel1.tick();
+        self.channel2.tick();
+        self.channel3.tick();
+        self.channel4.tick();
+
+        // フレームシーケンサ
+        self.frame_sequencer_timer = self.frame_sequencer_timer.saturating_sub(1);
+        if self.frame_sequencer_timer == 0 {
+            self.frame_sequencer_timer = FRAME_SEQUENCER_PERIOD;
+            self.clock_frame_sequencer();
+        }
+
+        // ダウンサンプリング (CPUクロック→サンプリングレート)
+        self.downsample_counter += self.sample_rate;
+        if self.downsample_counter >= 4_194_304 {
+            self.downsample_counter -= 4_194_304;
+            self.generate_sample();
+        }
+    }
+
+    /// フレームシーケンサのクロック
+    fn clock_frame_sequencer(&mut self) {
+        match self.frame_sequencer_step {
+            0 => {
+                // 長さカウンタ
+                self.channel1.clock_length();
+                self.channel2.clock_length();
+                self.channel3.clock_length();
+                self.channel4.clock_length();
+            }
+            1 => {} // なし
+            2 => {
+                // 長さカウンタ + スイープ
+                self.channel1.clock_length();
+                self.channel2.clock_length();
+                self.channel3.clock_length();
+                self.channel4.clock_length();
+                self.channel1.clock_sweep();
+            }
+            3 => {} // なし
+            4 => {
+                // 長さカウンタ
+                self.channel1.clock_length();
+                self.channel2.clock_length();
+                self.channel3.clock_length();
+                self.channel4.clock_length();
+            }
+            5 => {} // なし
+            6 => {
+                // 長さカウンタ + スイープ
+                self.channel1.clock_length();
+                self.channel2.clock_length();
+                self.channel3.clock_length();
+                self.channel4.clock_length();
+                self.channel1.clock_sweep();
+            }
+            7 => {
+                // エンベロープ
+                self.channel1.clock_envelope();
+                self.channel2.clock_envelope();
+                self.channel4.clock_envelope();
+            }
+            _ => {}
+        }
+
+        self.frame_sequencer_step = (self.frame_sequencer_step + 1) & 0x07;
+    }
+
+    /// オーディオサンプルを生成してバッファに追加
+    fn generate_sample(&mut self) {
+        let ch1 = self.channel1.dac_output();
+        let ch2 = self.channel2.dac_output();
+        let ch3 = self.channel3.dac_output();
+        let ch4 = self.channel4.dac_output();
+
+        // ミキシング（パニング適用）
+        let mut left: f32 = 0.0;
+        let mut right: f32 = 0.0;
+
+        if self.panning & 0x10 != 0 { left += ch1; }
+        if self.panning & 0x20 != 0 { left += ch2; }
+        if self.panning & 0x40 != 0 { left += ch3; }
+        if self.panning & 0x80 != 0 { left += ch4; }
+
+        if self.panning & 0x01 != 0 { right += ch1; }
+        if self.panning & 0x02 != 0 { right += ch2; }
+        if self.panning & 0x04 != 0 { right += ch3; }
+        if self.panning & 0x08 != 0 { right += ch4; }
+
+        // マスター音量適用 (0-7 → 1/8-8/8)
+        left *= (self.left_volume as f32 + 1.0) / 8.0;
+        right *= (self.right_volume as f32 + 1.0) / 8.0;
+
+        // 4チャンネル分の正規化
+        left /= 4.0;
+        right /= 4.0;
+
+        self.sample_buffer.push(left);
+        self.sample_buffer.push(right);
+    }
+
+    /// サンプルバッファを取り出す（取り出し後はクリア）
+    pub fn drain_samples(&mut self) -> Vec<f32> {
+        std::mem::take(&mut self.sample_buffer)
+    }
+
+    /// I/Oレジスタの読み取り
+    pub fn read(&self, addr: u16) -> u8 {
+        if !self.power && addr != NR52 {
+            // APU電源オフ時はNR52以外は読めない（Wave RAM除く）
+            if (WAVE_RAM_START..=WAVE_RAM_END).contains(&addr) {
+                return self.channel3.read_wave_ram(addr);
+            }
+            return 0xFF;
+        }
+
+        match addr {
+            // Channel 1
+            NR10 => self.channel1.read_sweep(),
+            NR11 => self.channel1.read_length_duty(),
+            NR12 => self.channel1.read_envelope(),
+            NR13 => 0xFF, // 書き込みのみ
+            NR14 => self.channel1.read_frequency_high(),
+
+            // Channel 2
+            NR21 => self.channel2.read_length_duty(),
+            NR22 => self.channel2.read_envelope(),
+            NR23 => 0xFF, // 書き込みのみ
+            NR24 => self.channel2.read_frequency_high(),
+
+            // Channel 3
+            NR30 => self.channel3.read_dac(),
+            NR31 => 0xFF, // 書き込みのみ
+            NR32 => self.channel3.read_output_level(),
+            NR33 => 0xFF, // 書き込みのみ
+            NR34 => self.channel3.read_frequency_high(),
+
+            // Channel 4
+            NR41 => 0xFF, // 書き込みのみ
+            NR42 => self.channel4.read_envelope(),
+            NR43 => self.channel4.read_polynomial(),
+            NR44 => self.channel4.read_control(),
+
+            // Master
+            NR50 => self.read_nr50(),
+            NR51 => self.panning,
+            NR52 => self.read_nr52(),
+
+            // Wave RAM
+            WAVE_RAM_START..=WAVE_RAM_END => self.channel3.read_wave_ram(addr),
+
+            _ => 0xFF,
+        }
+    }
+
+    /// I/Oレジスタへの書き込み
+    pub fn write(&mut self, addr: u16, value: u8) {
+        // Wave RAMはAPU電源に関係なく書き込み可能
+        if (WAVE_RAM_START..=WAVE_RAM_END).contains(&addr) {
+            self.channel3.write_wave_ram(addr, value);
+            return;
+        }
+
+        // NR52の電源ビットはいつでも書き込み可能
+        if addr == NR52 {
+            self.write_nr52(value);
+            return;
+        }
+
+        // APU電源オフ時は書き込み無視 (NR11/NR21/NR31/NR41の長さ除く)
+        if !self.power {
+            match addr {
+                NR11 => self.channel1.write_length_duty(value),
+                NR21 => self.channel2.write_length_duty(value),
+                NR31 => self.channel3.write_length(value),
+                NR41 => self.channel4.write_length(value),
+                _ => {}
+            }
+            return;
+        }
+
+        match addr {
+            // Channel 1
+            NR10 => self.channel1.write_sweep(value),
+            NR11 => self.channel1.write_length_duty(value),
+            NR12 => self.channel1.write_envelope(value),
+            NR13 => self.channel1.write_frequency_low(value),
+            NR14 => self.channel1.write_frequency_high(value),
+
+            // Channel 2
+            NR21 => self.channel2.write_length_duty(value),
+            NR22 => self.channel2.write_envelope(value),
+            NR23 => self.channel2.write_frequency_low(value),
+            NR24 => self.channel2.write_frequency_high(value),
+
+            // Channel 3
+            NR30 => self.channel3.write_dac(value),
+            NR31 => self.channel3.write_length(value),
+            NR32 => self.channel3.write_output_level(value),
+            NR33 => self.channel3.write_frequency_low(value),
+            NR34 => self.channel3.write_frequency_high(value),
+
+            // Channel 4
+            NR41 => self.channel4.write_length(value),
+            NR42 => self.channel4.write_envelope(value),
+            NR43 => self.channel4.write_polynomial(value),
+            NR44 => self.channel4.write_control(value),
+
+            // Master
+            NR50 => self.write_nr50(value),
+            NR51 => self.panning = value,
+
+            _ => {}
+        }
+    }
+
+    /// NR50レジスタの読み取り
+    fn read_nr50(&self) -> u8 {
+        (if self.vin_left { 0x80 } else { 0x00 })
+            | (self.left_volume << 4)
+            | (if self.vin_right { 0x08 } else { 0x00 })
+            | self.right_volume
+    }
+
+    /// NR50レジスタへの書き込み
+    fn write_nr50(&mut self, value: u8) {
+        self.vin_left = value & 0x80 != 0;
+        self.left_volume = (value >> 4) & 0x07;
+        self.vin_right = value & 0x08 != 0;
+        self.right_volume = value & 0x07;
+    }
+
+    /// NR52レジスタの読み取り
+    fn read_nr52(&self) -> u8 {
+        0x70 // bit 4-6は常に1
+            | if self.power { 0x80 } else { 0x00 }
+            | if self.channel4.enabled { 0x08 } else { 0x00 }
+            | if self.channel3.enabled { 0x04 } else { 0x00 }
+            | if self.channel2.enabled { 0x02 } else { 0x00 }
+            | if self.channel1.enabled { 0x01 } else { 0x00 }
+    }
+
+    /// NR52レジスタへの書き込み
+    fn write_nr52(&mut self, value: u8) {
+        let new_power = value & 0x80 != 0;
+
+        if self.power && !new_power {
+            // APU電源オフ: 全レジスタをクリア
+            self.power_off();
+        } else if !self.power && new_power {
+            // APU電源オン
+            self.frame_sequencer_step = 0;
+        }
+
+        self.power = new_power;
+    }
+
+    /// APU電源オフ時の全レジスタクリア
+    fn power_off(&mut self) {
+        self.channel1 = PulseChannel::new(true);
+        self.channel2 = PulseChannel::new(false);
+        // Wave RAMは保持
+        let wave_ram_backup = self.channel3.wave_ram;
+        self.channel3 = WaveChannel::new();
+        self.channel3.wave_ram = wave_ram_backup;
+        self.channel4 = NoiseChannel::new();
+
+        self.vin_left = false;
+        self.left_volume = 0;
+        self.vin_right = false;
+        self.right_volume = 0;
+        self.panning = 0;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_apu_creation() {
+        let apu = Apu::new();
+        assert!(!apu.power);
+        assert!(!apu.channel1.enabled);
+        assert!(!apu.channel2.enabled);
+        assert!(!apu.channel3.enabled);
+        assert!(!apu.channel4.enabled);
+    }
+
+    #[test]
+    fn test_apu_power_on_off() {
+        let mut apu = Apu::new();
+
+        // 電源オン
+        apu.write(NR52, 0x80);
+        assert!(apu.power);
+
+        // レジスタ書き込み可能
+        apu.write(NR50, 0x77); // 左右ボリューム最大
+        assert_eq!(apu.left_volume, 7);
+        assert_eq!(apu.right_volume, 7);
+
+        // 電源オフ
+        apu.write(NR52, 0x00);
+        assert!(!apu.power);
+        // レジスタがクリアされる
+        assert_eq!(apu.left_volume, 0);
+        assert_eq!(apu.right_volume, 0);
+    }
+
+    #[test]
+    fn test_apu_nr52_read() {
+        let mut apu = Apu::new();
+        apu.write(NR52, 0x80);
+
+        // 初期状態: 電源オン、全チャンネル無効
+        let nr52 = apu.read(NR52);
+        assert_eq!(nr52 & 0x80, 0x80); // 電源オン
+        assert_eq!(nr52 & 0x0F, 0x00); // 全チャンネル無効
+        assert_eq!(nr52 & 0x70, 0x70); // 未使用ビットは1
+    }
+
+    #[test]
+    fn test_apu_channel1_trigger() {
+        let mut apu = Apu::new();
+        apu.write(NR52, 0x80);
+
+        apu.write(NR12, 0xF0); // ボリューム15、DAC有効
+        apu.write(NR14, 0x80); // トリガー
+
+        assert!(apu.channel1.enabled);
+        let nr52 = apu.read(NR52);
+        assert_eq!(nr52 & 0x01, 0x01); // Channel 1 有効
+    }
+
+    #[test]
+    fn test_apu_nr50_register() {
+        let mut apu = Apu::new();
+        apu.write(NR52, 0x80);
+
+        apu.write(NR50, 0xA5);
+        assert!(apu.vin_left);
+        assert_eq!(apu.left_volume, 2);
+        assert!(!apu.vin_right);
+        assert_eq!(apu.right_volume, 5);
+        assert_eq!(apu.read(NR50), 0xA5);
+    }
+
+    #[test]
+    fn test_apu_nr51_panning() {
+        let mut apu = Apu::new();
+        apu.write(NR52, 0x80);
+
+        apu.write(NR51, 0x12);
+        assert_eq!(apu.panning, 0x12);
+        assert_eq!(apu.read(NR51), 0x12);
+    }
+
+    #[test]
+    fn test_apu_power_off_preserves_wave_ram() {
+        let mut apu = Apu::new();
+        apu.write(NR52, 0x80);
+
+        // Wave RAMにデータを書き込み
+        apu.write(WAVE_RAM_START, 0x12);
+        apu.write(WAVE_RAM_START + 1, 0x34);
+
+        // 電源オフ
+        apu.write(NR52, 0x00);
+
+        // Wave RAMは保持される
+        assert_eq!(apu.read(WAVE_RAM_START), 0x12);
+        assert_eq!(apu.read(WAVE_RAM_START + 1), 0x34);
+    }
+
+    #[test]
+    fn test_apu_wave_ram_accessible_when_off() {
+        let mut apu = Apu::new();
+        // 電源オフでもWave RAMは読み書き可能
+        assert!(!apu.power);
+
+        apu.write(WAVE_RAM_START, 0xAB);
+        assert_eq!(apu.read(WAVE_RAM_START), 0xAB);
+    }
+
+    #[test]
+    fn test_apu_registers_locked_when_off() {
+        let mut apu = Apu::new();
+        // APU電源オフ時はレジスタに書き込めない
+        apu.write(NR50, 0x77);
+        assert_eq!(apu.left_volume, 0); // 変更されない
+
+        // NR52は書き込み可能
+        apu.write(NR52, 0x80);
+        assert!(apu.power);
+    }
+
+    #[test]
+    fn test_apu_tick_generates_samples() {
+        let mut apu = Apu::new();
+        apu.write(NR52, 0x80);
+
+        // しばらくtick
+        for _ in 0..44100 {
+            apu.tick();
+        }
+
+        // サンプルが生成されているはず
+        let samples = apu.drain_samples();
+        assert!(!samples.is_empty());
+        // ステレオなので偶数
+        assert_eq!(samples.len() % 2, 0);
+    }
+
+    #[test]
+    fn test_apu_no_tick_when_off() {
+        let mut apu = Apu::new();
+        // 電源オフではtickしてもサンプルが生成されない
+        for _ in 0..1000 {
+            apu.tick();
+        }
+        let samples = apu.drain_samples();
+        assert!(samples.is_empty());
+    }
+
+    #[test]
+    fn test_apu_read_write_only_registers() {
+        let mut apu = Apu::new();
+        apu.write(NR52, 0x80);
+
+        // 書き込みのみのレジスタは0xFFを返す
+        assert_eq!(apu.read(NR13), 0xFF);
+        assert_eq!(apu.read(NR23), 0xFF);
+        assert_eq!(apu.read(NR31), 0xFF);
+        assert_eq!(apu.read(NR33), 0xFF);
+        assert_eq!(apu.read(NR41), 0xFF);
+    }
+
+    #[test]
+    fn test_frame_sequencer_length() {
+        let mut apu = Apu::new();
+        apu.write(NR52, 0x80);
+
+        // Channel 1に短い長さカウンタを設定
+        apu.write(NR12, 0xF0); // DAC有効
+        apu.write(NR11, 0x3F); // length_data=63 → counter=1
+        apu.write(NR14, 0xC0); // トリガー + 長さ有効
+
+        assert!(apu.channel1.enabled);
+
+        // フレームシーケンサのstep 0まで進める (8192サイクル)
+        for _ in 0..8192 {
+            apu.tick();
+        }
+
+        // 長さカウンタが消費されてチャンネル無効化
+        assert!(!apu.channel1.enabled);
+    }
+}

--- a/src/apu/noise.rs
+++ b/src/apu/noise.rs
@@ -1,0 +1,323 @@
+// src/apu/noise.rs
+// GameBoy APU ノイズチャンネル (Channel 4)
+//
+// NR41 (0xFF20): 長さ
+//   Bit 5-0: 長さデータ (t1: 0-63)
+// NR42 (0xFF21): エンベロープ
+//   Bit 7-4: 初期ボリューム
+//   Bit 3:   方向 (0=減少, 1=増加)
+//   Bit 2-0: 周期
+// NR43 (0xFF22): 多項式カウンタ
+//   Bit 7-4: シフトクロック周波数 (s)
+//   Bit 3:   カウンタ幅 (0=15ビット, 1=7ビット)
+//   Bit 2-0: 分周比 (r)
+//   周波数 = 524288 Hz / r / 2^(s+1)  (r=0は0.5として扱う)
+// NR44 (0xFF23): 制御
+//   Bit 7:   トリガー
+//   Bit 6:   長さ有効
+
+/// ノイズチャンネル
+pub struct NoiseChannel {
+    /// チャンネル有効フラグ
+    pub enabled: bool,
+    /// DAC有効フラグ
+    pub dac_enabled: bool,
+
+    /// 長さカウンタ
+    pub length_counter: u16,
+    /// 長さ有効フラグ
+    pub length_enabled: bool,
+
+    // エンベロープ
+    /// エンベロープ初期ボリューム
+    pub envelope_initial: u8,
+    /// エンベロープ方向
+    pub envelope_direction: bool,
+    /// エンベロープ周期
+    pub envelope_period: u8,
+    /// 現在のボリューム
+    pub volume: u8,
+    /// エンベロープタイマー
+    envelope_timer: u8,
+
+    // 多項式カウンタ
+    /// シフトクロック
+    pub clock_shift: u8,
+    /// カウンタ幅 (true=7ビット, false=15ビット)
+    pub width_mode: bool,
+    /// 分周比
+    pub divisor_code: u8,
+
+    /// LFSR (線形フィードバックシフトレジスタ)
+    lfsr: u16,
+    /// 周波数タイマー
+    frequency_timer: u16,
+}
+
+/// 分周比テーブル
+const DIVISOR_TABLE: [u16; 8] = [8, 16, 32, 48, 64, 80, 96, 112];
+
+impl NoiseChannel {
+    pub fn new() -> Self {
+        Self {
+            enabled: false,
+            dac_enabled: false,
+            length_counter: 0,
+            length_enabled: false,
+            envelope_initial: 0,
+            envelope_direction: false,
+            envelope_period: 0,
+            volume: 0,
+            envelope_timer: 0,
+            clock_shift: 0,
+            width_mode: false,
+            divisor_code: 0,
+            lfsr: 0x7FFF, // 15ビット全て1で初期化
+            frequency_timer: 0,
+        }
+    }
+
+    /// NR41 長さレジスタへの書き込み (書き込みのみ)
+    pub fn write_length(&mut self, value: u8) {
+        let length_data = value & 0x3F;
+        self.length_counter = 64 - length_data as u16;
+    }
+
+    /// NR42 エンベロープレジスタの読み取り
+    pub fn read_envelope(&self) -> u8 {
+        (self.envelope_initial << 4)
+            | if self.envelope_direction { 0x08 } else { 0x00 }
+            | self.envelope_period
+    }
+
+    /// NR42 エンベロープレジスタへの書き込み
+    pub fn write_envelope(&mut self, value: u8) {
+        self.envelope_initial = (value >> 4) & 0x0F;
+        self.envelope_direction = value & 0x08 != 0;
+        self.envelope_period = value & 0x07;
+        self.dac_enabled = value & 0xF8 != 0;
+        if !self.dac_enabled {
+            self.enabled = false;
+        }
+    }
+
+    /// NR43 多項式カウンタレジスタの読み取り
+    pub fn read_polynomial(&self) -> u8 {
+        (self.clock_shift << 4)
+            | if self.width_mode { 0x08 } else { 0x00 }
+            | self.divisor_code
+    }
+
+    /// NR43 多項式カウンタレジスタへの書き込み
+    pub fn write_polynomial(&mut self, value: u8) {
+        self.clock_shift = (value >> 4) & 0x0F;
+        self.width_mode = value & 0x08 != 0;
+        self.divisor_code = value & 0x07;
+    }
+
+    /// NR44 制御レジスタの読み取り
+    pub fn read_control(&self) -> u8 {
+        0xBF | if self.length_enabled { 0x40 } else { 0x00 }
+    }
+
+    /// NR44 制御レジスタへの書き込み
+    pub fn write_control(&mut self, value: u8) {
+        self.length_enabled = value & 0x40 != 0;
+
+        if value & 0x80 != 0 {
+            self.trigger();
+        }
+    }
+
+    /// チャンネルトリガー
+    fn trigger(&mut self) {
+        self.enabled = self.dac_enabled;
+
+        if self.length_counter == 0 {
+            self.length_counter = 64;
+        }
+
+        // 周波数タイマーリロード
+        self.frequency_timer = self.get_period();
+
+        // LFSR初期化
+        self.lfsr = 0x7FFF;
+
+        // エンベロープリロード
+        self.volume = self.envelope_initial;
+        self.envelope_timer = if self.envelope_period == 0 { 8 } else { self.envelope_period };
+    }
+
+    /// 周波数タイマー周期を計算
+    fn get_period(&self) -> u16 {
+        DIVISOR_TABLE[self.divisor_code as usize] << self.clock_shift
+    }
+
+    /// 長さカウンタをクロック
+    pub fn clock_length(&mut self) {
+        if self.length_enabled && self.length_counter > 0 {
+            self.length_counter -= 1;
+            if self.length_counter == 0 {
+                self.enabled = false;
+            }
+        }
+    }
+
+    /// エンベロープをクロック
+    pub fn clock_envelope(&mut self) {
+        if self.envelope_period == 0 {
+            return;
+        }
+
+        self.envelope_timer = self.envelope_timer.saturating_sub(1);
+        if self.envelope_timer == 0 {
+            self.envelope_timer = if self.envelope_period == 0 { 8 } else { self.envelope_period };
+
+            if self.envelope_direction && self.volume < 15 {
+                self.volume += 1;
+            } else if !self.envelope_direction && self.volume > 0 {
+                self.volume -= 1;
+            }
+        }
+    }
+
+    /// 周波数タイマーを1サイクル進める
+    pub fn tick(&mut self) {
+        if self.frequency_timer > 0 {
+            self.frequency_timer -= 1;
+        }
+
+        if self.frequency_timer == 0 {
+            self.frequency_timer = self.get_period();
+
+            // LFSRクロック
+            let xor_result = (self.lfsr & 0x01) ^ ((self.lfsr >> 1) & 0x01);
+            self.lfsr = (self.lfsr >> 1) | (xor_result << 14);
+
+            // 7ビットモードではbit6にもセット
+            if self.width_mode {
+                self.lfsr = (self.lfsr & !0x0040) | (xor_result << 6);
+            }
+        }
+    }
+
+    /// 現在の出力サンプル (0-15)
+    pub fn output(&self) -> u8 {
+        if !self.enabled || !self.dac_enabled {
+            return 0;
+        }
+        // LFSRのbit0が0ならHigh出力
+        if self.lfsr & 0x01 == 0 {
+            self.volume
+        } else {
+            0
+        }
+    }
+
+    /// DAC出力 (-1.0 ~ 1.0)
+    pub fn dac_output(&self) -> f32 {
+        if !self.dac_enabled {
+            return 0.0;
+        }
+        let digital = self.output();
+        (digital as f32 / 7.5) - 1.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_noise_channel_creation() {
+        let ch = NoiseChannel::new();
+        assert!(!ch.enabled);
+        assert!(!ch.dac_enabled);
+        assert_eq!(ch.lfsr, 0x7FFF);
+        assert_eq!(ch.output(), 0);
+    }
+
+    #[test]
+    fn test_noise_length() {
+        let mut ch = NoiseChannel::new();
+        ch.write_length(62); // counter = 64 - 62 = 2
+        assert_eq!(ch.length_counter, 2);
+    }
+
+    #[test]
+    fn test_noise_envelope_register() {
+        let mut ch = NoiseChannel::new();
+        ch.write_envelope(0xA5); // vol=10, down, period=5
+        assert_eq!(ch.envelope_initial, 10);
+        assert!(!ch.envelope_direction);
+        assert_eq!(ch.envelope_period, 5);
+        assert!(ch.dac_enabled);
+        assert_eq!(ch.read_envelope(), 0xA5);
+    }
+
+    #[test]
+    fn test_noise_polynomial_register() {
+        let mut ch = NoiseChannel::new();
+        ch.write_polynomial(0x63); // shift=6, 15bit, divisor=3
+        assert_eq!(ch.clock_shift, 6);
+        assert!(!ch.width_mode);
+        assert_eq!(ch.divisor_code, 3);
+        assert_eq!(ch.read_polynomial(), 0x63);
+    }
+
+    #[test]
+    fn test_noise_width_mode() {
+        let mut ch = NoiseChannel::new();
+        ch.write_polynomial(0x08); // 7ビットモード
+        assert!(ch.width_mode);
+    }
+
+    #[test]
+    fn test_noise_trigger() {
+        let mut ch = NoiseChannel::new();
+        ch.write_envelope(0xF0); // DAC有効
+        ch.write_control(0x80); // トリガー
+
+        assert!(ch.enabled);
+        assert_eq!(ch.volume, 15);
+        assert_eq!(ch.lfsr, 0x7FFF);
+    }
+
+    #[test]
+    fn test_noise_length_counter() {
+        let mut ch = NoiseChannel::new();
+        ch.write_envelope(0xF0);
+        ch.write_length(63); // counter = 1
+        ch.write_control(0xC0); // トリガー + 長さ有効
+
+        assert!(ch.enabled);
+        ch.clock_length();
+        assert!(!ch.enabled);
+    }
+
+    #[test]
+    fn test_noise_lfsr_shift() {
+        let mut ch = NoiseChannel::new();
+        ch.write_envelope(0xF0);
+        ch.write_polynomial(0x00); // shift=0, 15bit, divisor=0
+        ch.write_control(0x80); // トリガー
+
+        let initial_lfsr = ch.lfsr;
+
+        // LFSRを数回クロック
+        let period = 8u16; // divisor_code=0 → 8サイクル
+        for _ in 0..period {
+            ch.tick();
+        }
+
+        // LFSRが変化しているはず
+        assert_ne!(ch.lfsr, initial_lfsr);
+    }
+
+    #[test]
+    fn test_noise_disabled_output() {
+        let ch = NoiseChannel::new();
+        assert_eq!(ch.output(), 0);
+        assert_eq!(ch.dac_output(), 0.0);
+    }
+}

--- a/src/apu/pulse.rs
+++ b/src/apu/pulse.rs
@@ -1,0 +1,421 @@
+// src/apu/pulse.rs
+// GameBoy APU パルスチャンネル (Channel 1/2)
+//
+// Channel 1: NR10(スイープ), NR11(長さ/デューティ), NR12(エンベロープ), NR13(周波数下位), NR14(周波数上位/制御)
+// Channel 2: NR21(長さ/デューティ), NR22(エンベロープ), NR23(周波数下位), NR24(周波数上位/制御)
+//
+// デューティサイクルパターン:
+//   00: 12.5% (________------__)
+//   01: 25.0% (________------_-)
+//   10: 50.0% (____----____----)
+//   11: 75.0% (________--____--)
+//
+// スイープ (Channel 1のみ):
+//   周波数を周期的にシフトして変更
+
+/// デューティサイクル波形テーブル
+/// 各デューティパターンの8ステップ (0=Low, 1=High)
+const DUTY_TABLE: [[u8; 8]; 4] = [
+    [0, 0, 0, 0, 0, 0, 0, 1], // 12.5%
+    [1, 0, 0, 0, 0, 0, 0, 1], // 25.0%
+    [1, 0, 0, 0, 0, 1, 1, 1], // 50.0%
+    [0, 1, 1, 1, 1, 1, 1, 0], // 75.0%
+];
+
+/// パルスチャンネル
+pub struct PulseChannel {
+    /// チャンネル有効フラグ
+    pub enabled: bool,
+    /// DAC有効フラグ
+    pub dac_enabled: bool,
+
+    // NRx1: デューティ/長さ
+    /// デューティサイクル (0-3)
+    pub duty: u8,
+    /// 長さカウンタ
+    pub length_counter: u16,
+    /// 長さ有効フラグ
+    pub length_enabled: bool,
+
+    // NRx2: エンベロープ
+    /// エンベロープ初期ボリューム (0-15)
+    pub envelope_initial: u8,
+    /// エンベロープ方向 (true=増加, false=減少)
+    pub envelope_direction: bool,
+    /// エンベロープ周期 (0-7)
+    pub envelope_period: u8,
+    /// 現在のボリューム
+    pub volume: u8,
+    /// エンベロープタイマー
+    envelope_timer: u8,
+
+    // NRx3/NRx4: 周波数
+    /// 周波数値 (11ビット)
+    pub frequency: u16,
+    /// 周波数タイマー
+    frequency_timer: u16,
+    /// デューティステップ位置
+    duty_position: u8,
+
+    // NR10: スイープ (Channel 1のみ)
+    /// スイープ有効フラグ
+    pub sweep_enabled: bool,
+    /// スイープ周期 (0-7)
+    pub sweep_period: u8,
+    /// スイープ方向 (true=減少, false=増加)
+    pub sweep_negate: bool,
+    /// スイープシフト量 (0-7)
+    pub sweep_shift: u8,
+    /// スイープタイマー
+    sweep_timer: u8,
+    /// スイープシャドウ周波数
+    sweep_shadow: u16,
+    /// スイープで減算を使用したか
+    sweep_negate_used: bool,
+    /// スイープ機能を持つか (Channel 1のみ)
+    has_sweep: bool,
+}
+
+impl PulseChannel {
+    /// 新しいパルスチャンネルを作成
+    pub fn new(has_sweep: bool) -> Self {
+        Self {
+            enabled: false,
+            dac_enabled: false,
+            duty: 0,
+            length_counter: 0,
+            length_enabled: false,
+            envelope_initial: 0,
+            envelope_direction: false,
+            envelope_period: 0,
+            volume: 0,
+            envelope_timer: 0,
+            frequency: 0,
+            frequency_timer: 0,
+            duty_position: 0,
+            sweep_enabled: false,
+            sweep_period: 0,
+            sweep_negate: false,
+            sweep_shift: 0,
+            sweep_timer: 0,
+            sweep_shadow: 0,
+            sweep_negate_used: false,
+            has_sweep,
+        }
+    }
+
+    /// NR10 スイープレジスタの読み取り
+    pub fn read_sweep(&self) -> u8 {
+        0x80 // bit7は常に1
+            | (self.sweep_period << 4)
+            | if self.sweep_negate { 0x08 } else { 0x00 }
+            | self.sweep_shift
+    }
+
+    /// NR10 スイープレジスタへの書き込み
+    pub fn write_sweep(&mut self, value: u8) {
+        self.sweep_period = (value >> 4) & 0x07;
+        let new_negate = value & 0x08 != 0;
+        // 減算モードから加算モードへの切り替えでチャンネル無効化
+        if self.sweep_negate && !new_negate && self.sweep_negate_used {
+            self.enabled = false;
+        }
+        self.sweep_negate = new_negate;
+        self.sweep_shift = value & 0x07;
+    }
+
+    /// NRx1 長さ/デューティレジスタの読み取り (上位2ビットのみ読める)
+    pub fn read_length_duty(&self) -> u8 {
+        (self.duty << 6) | 0x3F // 下位6ビットは常に1
+    }
+
+    /// NRx1 長さ/デューティレジスタへの書き込み
+    pub fn write_length_duty(&mut self, value: u8) {
+        self.duty = (value >> 6) & 0x03;
+        let length_data = value & 0x3F;
+        self.length_counter = 64 - length_data as u16;
+    }
+
+    /// NRx2 エンベロープレジスタの読み取り
+    pub fn read_envelope(&self) -> u8 {
+        (self.envelope_initial << 4)
+            | if self.envelope_direction { 0x08 } else { 0x00 }
+            | self.envelope_period
+    }
+
+    /// NRx2 エンベロープレジスタへの書き込み
+    pub fn write_envelope(&mut self, value: u8) {
+        self.envelope_initial = (value >> 4) & 0x0F;
+        self.envelope_direction = value & 0x08 != 0;
+        self.envelope_period = value & 0x07;
+        // DACは上位5ビットが0以外なら有効
+        self.dac_enabled = value & 0xF8 != 0;
+        if !self.dac_enabled {
+            self.enabled = false;
+        }
+    }
+
+    /// NRx3 周波数下位レジスタへの書き込み (書き込みのみ)
+    pub fn write_frequency_low(&mut self, value: u8) {
+        self.frequency = (self.frequency & 0x700) | value as u16;
+    }
+
+    /// NRx4 周波数上位/制御レジスタの読み取り
+    pub fn read_frequency_high(&self) -> u8 {
+        0xBF | if self.length_enabled { 0x40 } else { 0x00 } // bit6のみ読める
+    }
+
+    /// NRx4 周波数上位/制御レジスタへの書き込み
+    pub fn write_frequency_high(&mut self, value: u8) {
+        self.length_enabled = value & 0x40 != 0;
+        self.frequency = (self.frequency & 0x00FF) | ((value as u16 & 0x07) << 8);
+
+        // トリガー
+        if value & 0x80 != 0 {
+            self.trigger();
+        }
+    }
+
+    /// チャンネルトリガー
+    fn trigger(&mut self) {
+        self.enabled = self.dac_enabled;
+
+        // 長さカウンタが0なら最大値に
+        if self.length_counter == 0 {
+            self.length_counter = 64;
+        }
+
+        // 周波数タイマーリロード
+        self.frequency_timer = (2048 - self.frequency) * 4;
+
+        // エンベロープリロード
+        self.volume = self.envelope_initial;
+        self.envelope_timer = if self.envelope_period == 0 { 8 } else { self.envelope_period };
+
+        // スイープ初期化
+        if self.has_sweep {
+            self.sweep_shadow = self.frequency;
+            self.sweep_timer = if self.sweep_period == 0 { 8 } else { self.sweep_period };
+            self.sweep_enabled = self.sweep_period != 0 || self.sweep_shift != 0;
+            self.sweep_negate_used = false;
+
+            // スイープシフトが0でない場合、オーバーフローチェック
+            if self.sweep_shift != 0 {
+                let new_freq = self.calculate_sweep_frequency();
+                if new_freq > 2047 {
+                    self.enabled = false;
+                }
+            }
+        }
+    }
+
+    /// スイープによる新しい周波数を計算
+    fn calculate_sweep_frequency(&mut self) -> u16 {
+        let shifted = self.sweep_shadow >> self.sweep_shift;
+        if self.sweep_negate {
+            self.sweep_negate_used = true;
+            self.sweep_shadow.wrapping_sub(shifted)
+        } else {
+            self.sweep_shadow.wrapping_add(shifted)
+        }
+    }
+
+    /// スイープをクロック
+    pub fn clock_sweep(&mut self) {
+        if !self.has_sweep {
+            return;
+        }
+
+        self.sweep_timer = self.sweep_timer.saturating_sub(1);
+        if self.sweep_timer == 0 {
+            self.sweep_timer = if self.sweep_period == 0 { 8 } else { self.sweep_period };
+
+            if self.sweep_enabled && self.sweep_period != 0 {
+                let new_freq = self.calculate_sweep_frequency();
+                if new_freq > 2047 {
+                    self.enabled = false;
+                } else if self.sweep_shift != 0 {
+                    self.sweep_shadow = new_freq;
+                    self.frequency = new_freq;
+
+                    // 再度オーバーフローチェック
+                    let check_freq = self.calculate_sweep_frequency();
+                    if check_freq > 2047 {
+                        self.enabled = false;
+                    }
+                }
+            }
+        }
+    }
+
+    /// 長さカウンタをクロック
+    pub fn clock_length(&mut self) {
+        if self.length_enabled && self.length_counter > 0 {
+            self.length_counter -= 1;
+            if self.length_counter == 0 {
+                self.enabled = false;
+            }
+        }
+    }
+
+    /// エンベロープをクロック
+    pub fn clock_envelope(&mut self) {
+        if self.envelope_period == 0 {
+            return;
+        }
+
+        self.envelope_timer = self.envelope_timer.saturating_sub(1);
+        if self.envelope_timer == 0 {
+            self.envelope_timer = if self.envelope_period == 0 { 8 } else { self.envelope_period };
+
+            if self.envelope_direction && self.volume < 15 {
+                self.volume += 1;
+            } else if !self.envelope_direction && self.volume > 0 {
+                self.volume -= 1;
+            }
+        }
+    }
+
+    /// 周波数タイマーを1サイクル進める
+    pub fn tick(&mut self) {
+        if self.frequency_timer > 0 {
+            self.frequency_timer -= 1;
+        }
+
+        if self.frequency_timer == 0 {
+            self.frequency_timer = (2048 - self.frequency) * 4;
+            self.duty_position = (self.duty_position + 1) & 0x07;
+        }
+    }
+
+    /// 現在の出力サンプル (0-15)
+    pub fn output(&self) -> u8 {
+        if !self.enabled || !self.dac_enabled {
+            return 0;
+        }
+        let wave = DUTY_TABLE[self.duty as usize][self.duty_position as usize];
+        if wave != 0 { self.volume } else { 0 }
+    }
+
+    /// DAC出力 (-1.0 ~ 1.0 の範囲、DACオフ時は0.0)
+    pub fn dac_output(&self) -> f32 {
+        if !self.dac_enabled {
+            return 0.0;
+        }
+        let digital = self.output();
+        (digital as f32 / 7.5) - 1.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_pulse_channel_creation() {
+        let ch = PulseChannel::new(false);
+        assert!(!ch.enabled);
+        assert!(!ch.dac_enabled);
+        assert_eq!(ch.output(), 0);
+    }
+
+    #[test]
+    fn test_pulse_channel_with_sweep() {
+        let ch = PulseChannel::new(true);
+        assert!(ch.has_sweep);
+    }
+
+    #[test]
+    fn test_duty_register() {
+        let mut ch = PulseChannel::new(false);
+        ch.write_length_duty(0x80); // duty=2 (50%), length=0
+        assert_eq!(ch.duty, 2);
+        assert_eq!(ch.length_counter, 64);
+        assert_eq!(ch.read_length_duty() & 0xC0, 0x80);
+    }
+
+    #[test]
+    fn test_envelope_register() {
+        let mut ch = PulseChannel::new(false);
+        ch.write_envelope(0xF3); // volume=15, up, period=3
+        assert_eq!(ch.envelope_initial, 15);
+        assert!(!ch.envelope_direction); // bit3=0: 減少
+        assert_eq!(ch.envelope_period, 3);
+        assert!(ch.dac_enabled);
+        assert_eq!(ch.read_envelope(), 0xF3);
+    }
+
+    #[test]
+    fn test_envelope_dac_disable() {
+        let mut ch = PulseChannel::new(false);
+        ch.write_envelope(0x00); // volume=0, down, period=0 → DAC無効
+        assert!(!ch.dac_enabled);
+    }
+
+    #[test]
+    fn test_trigger() {
+        let mut ch = PulseChannel::new(false);
+        ch.write_envelope(0xF0); // volume=15 (DAC有効)
+        ch.write_frequency_low(0x00);
+        ch.write_frequency_high(0x80); // トリガー
+
+        assert!(ch.enabled);
+        assert_eq!(ch.volume, 15);
+    }
+
+    #[test]
+    fn test_length_counter() {
+        let mut ch = PulseChannel::new(false);
+        ch.write_envelope(0xF0); // DAC有効
+        ch.write_length_duty(0x3E); // length_data=62 → counter=2
+        ch.write_frequency_high(0xC0); // トリガー + 長さ有効
+
+        assert!(ch.enabled);
+        assert_eq!(ch.length_counter, 2);
+
+        ch.clock_length();
+        assert!(ch.enabled);
+        assert_eq!(ch.length_counter, 1);
+
+        ch.clock_length();
+        assert!(!ch.enabled);
+        assert_eq!(ch.length_counter, 0);
+    }
+
+    #[test]
+    fn test_sweep_register() {
+        let mut ch = PulseChannel::new(true);
+        ch.write_sweep(0x7B); // period=7, negate, shift=3
+        assert_eq!(ch.sweep_period, 7);
+        assert!(ch.sweep_negate);
+        assert_eq!(ch.sweep_shift, 3);
+        assert_eq!(ch.read_sweep(), 0xFB); // bit7=1 + 0x7B
+    }
+
+    #[test]
+    fn test_frequency_write() {
+        let mut ch = PulseChannel::new(false);
+        ch.write_frequency_low(0x73);
+        ch.write_frequency_high(0x06); // freq上位3ビット = 6
+        assert_eq!(ch.frequency, 0x673);
+    }
+
+    #[test]
+    fn test_envelope_clock() {
+        let mut ch = PulseChannel::new(false);
+        ch.write_envelope(0x71); // volume=7, down, period=1
+        ch.write_frequency_high(0x80); // トリガー
+        assert_eq!(ch.volume, 7);
+
+        ch.clock_envelope(); // タイマー消費
+        ch.clock_envelope(); // ボリューム変更
+        // 正確なタイミングはトリガー時のセットアップに依存
+    }
+
+    #[test]
+    fn test_output_when_disabled() {
+        let ch = PulseChannel::new(false);
+        assert_eq!(ch.output(), 0);
+        assert_eq!(ch.dac_output(), 0.0);
+    }
+}

--- a/src/apu/wave.rs
+++ b/src/apu/wave.rs
@@ -1,0 +1,292 @@
+// src/apu/wave.rs
+// GameBoy APU ウェーブチャンネル (Channel 3)
+//
+// NR30 (0xFF1A): チャンネルオン/オフ
+//   Bit 7: DAC電源 (1=オン)
+// NR31 (0xFF1B): 長さ
+//   Bit 7-0: 長さデータ (0-255)
+// NR32 (0xFF1C): 出力レベル
+//   Bit 6-5: 出力レベル (0=無音, 1=100%, 2=50%, 3=25%)
+// NR33 (0xFF1D): 周波数下位
+// NR34 (0xFF1E): 周波数上位/制御
+//
+// Wave RAM (0xFF30-0xFF3F): 16バイト = 32サンプル (各4ビット)
+
+/// ウェーブチャンネル
+pub struct WaveChannel {
+    /// チャンネル有効フラグ
+    pub enabled: bool,
+    /// DAC有効フラグ
+    pub dac_enabled: bool,
+
+    /// 長さカウンタ
+    pub length_counter: u16,
+    /// 長さ有効フラグ
+    pub length_enabled: bool,
+
+    /// 出力レベル (0-3)
+    pub output_level: u8,
+
+    /// 周波数値 (11ビット)
+    pub frequency: u16,
+    /// 周波数タイマー
+    frequency_timer: u16,
+
+    /// Wave RAM (16バイト = 32サンプル)
+    pub wave_ram: [u8; 16],
+    /// 現在のサンプル位置 (0-31)
+    sample_position: u8,
+    /// 現在のサンプルバッファ
+    sample_buffer: u8,
+}
+
+impl WaveChannel {
+    pub fn new() -> Self {
+        Self {
+            enabled: false,
+            dac_enabled: false,
+            length_counter: 0,
+            length_enabled: false,
+            output_level: 0,
+            frequency: 0,
+            frequency_timer: 0,
+            wave_ram: [0; 16],
+            sample_position: 0,
+            sample_buffer: 0,
+        }
+    }
+
+    /// NR30 DAC電源レジスタの読み取り
+    pub fn read_dac(&self) -> u8 {
+        0x7F | if self.dac_enabled { 0x80 } else { 0x00 }
+    }
+
+    /// NR30 DAC電源レジスタへの書き込み
+    pub fn write_dac(&mut self, value: u8) {
+        self.dac_enabled = value & 0x80 != 0;
+        if !self.dac_enabled {
+            self.enabled = false;
+        }
+    }
+
+    /// NR31 長さレジスタへの書き込み (書き込みのみ)
+    pub fn write_length(&mut self, value: u8) {
+        self.length_counter = 256 - value as u16;
+    }
+
+    /// NR32 出力レベルレジスタの読み取り
+    pub fn read_output_level(&self) -> u8 {
+        0x9F | (self.output_level << 5)
+    }
+
+    /// NR32 出力レベルレジスタへの書き込み
+    pub fn write_output_level(&mut self, value: u8) {
+        self.output_level = (value >> 5) & 0x03;
+    }
+
+    /// NR33 周波数下位レジスタへの書き込み (書き込みのみ)
+    pub fn write_frequency_low(&mut self, value: u8) {
+        self.frequency = (self.frequency & 0x700) | value as u16;
+    }
+
+    /// NR34 周波数上位/制御レジスタの読み取り
+    pub fn read_frequency_high(&self) -> u8 {
+        0xBF | if self.length_enabled { 0x40 } else { 0x00 }
+    }
+
+    /// NR34 周波数上位/制御レジスタへの書き込み
+    pub fn write_frequency_high(&mut self, value: u8) {
+        self.length_enabled = value & 0x40 != 0;
+        self.frequency = (self.frequency & 0x00FF) | ((value as u16 & 0x07) << 8);
+
+        if value & 0x80 != 0 {
+            self.trigger();
+        }
+    }
+
+    /// Wave RAMの読み取り
+    pub fn read_wave_ram(&self, addr: u16) -> u8 {
+        let index = (addr - 0xFF30) as usize;
+        if index < 16 {
+            self.wave_ram[index]
+        } else {
+            0xFF
+        }
+    }
+
+    /// Wave RAMへの書き込み
+    pub fn write_wave_ram(&mut self, addr: u16, value: u8) {
+        let index = (addr - 0xFF30) as usize;
+        if index < 16 {
+            self.wave_ram[index] = value;
+        }
+    }
+
+    /// チャンネルトリガー
+    fn trigger(&mut self) {
+        self.enabled = self.dac_enabled;
+
+        if self.length_counter == 0 {
+            self.length_counter = 256;
+        }
+
+        // 周波数タイマーリロード
+        self.frequency_timer = (2048 - self.frequency) * 2;
+        self.sample_position = 0;
+    }
+
+    /// 長さカウンタをクロック
+    pub fn clock_length(&mut self) {
+        if self.length_enabled && self.length_counter > 0 {
+            self.length_counter -= 1;
+            if self.length_counter == 0 {
+                self.enabled = false;
+            }
+        }
+    }
+
+    /// 周波数タイマーを1サイクル進める
+    pub fn tick(&mut self) {
+        if self.frequency_timer > 0 {
+            self.frequency_timer -= 1;
+        }
+
+        if self.frequency_timer == 0 {
+            self.frequency_timer = (2048 - self.frequency) * 2;
+            self.sample_position = (self.sample_position + 1) & 0x1F;
+
+            // Wave RAMから現在のサンプルを読み出し
+            let byte_index = (self.sample_position / 2) as usize;
+            if self.sample_position & 1 == 0 {
+                // 上位ニブル
+                self.sample_buffer = (self.wave_ram[byte_index] >> 4) & 0x0F;
+            } else {
+                // 下位ニブル
+                self.sample_buffer = self.wave_ram[byte_index] & 0x0F;
+            }
+        }
+    }
+
+    /// 現在の出力サンプル (0-15)
+    pub fn output(&self) -> u8 {
+        if !self.enabled || !self.dac_enabled {
+            return 0;
+        }
+
+        let sample = self.sample_buffer;
+        match self.output_level {
+            0 => 0,                  // 無音
+            1 => sample,             // 100%
+            2 => sample >> 1,        // 50%
+            3 => sample >> 2,        // 25%
+            _ => 0,
+        }
+    }
+
+    /// DAC出力 (-1.0 ~ 1.0)
+    pub fn dac_output(&self) -> f32 {
+        if !self.dac_enabled {
+            return 0.0;
+        }
+        let digital = self.output();
+        (digital as f32 / 7.5) - 1.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_wave_channel_creation() {
+        let ch = WaveChannel::new();
+        assert!(!ch.enabled);
+        assert!(!ch.dac_enabled);
+        assert_eq!(ch.output(), 0);
+        assert_eq!(ch.wave_ram, [0; 16]);
+    }
+
+    #[test]
+    fn test_wave_dac_register() {
+        let mut ch = WaveChannel::new();
+        ch.write_dac(0x80);
+        assert!(ch.dac_enabled);
+        assert_eq!(ch.read_dac(), 0xFF);
+
+        ch.write_dac(0x00);
+        assert!(!ch.dac_enabled);
+        assert_eq!(ch.read_dac(), 0x7F);
+    }
+
+    #[test]
+    fn test_wave_output_level() {
+        let mut ch = WaveChannel::new();
+        ch.write_output_level(0x40); // level=2 (50%)
+        assert_eq!(ch.output_level, 2);
+        assert_eq!(ch.read_output_level() & 0x60, 0x40);
+    }
+
+    #[test]
+    fn test_wave_ram_read_write() {
+        let mut ch = WaveChannel::new();
+        ch.write_wave_ram(0xFF30, 0x12);
+        ch.write_wave_ram(0xFF31, 0x34);
+        ch.write_wave_ram(0xFF3F, 0xAB);
+
+        assert_eq!(ch.read_wave_ram(0xFF30), 0x12);
+        assert_eq!(ch.read_wave_ram(0xFF31), 0x34);
+        assert_eq!(ch.read_wave_ram(0xFF3F), 0xAB);
+    }
+
+    #[test]
+    fn test_wave_trigger() {
+        let mut ch = WaveChannel::new();
+        ch.write_dac(0x80); // DAC有効
+        ch.write_frequency_low(0x00);
+        ch.write_frequency_high(0x80); // トリガー
+
+        assert!(ch.enabled);
+        assert_eq!(ch.sample_position, 0);
+    }
+
+    #[test]
+    fn test_wave_length_counter() {
+        let mut ch = WaveChannel::new();
+        ch.write_dac(0x80);
+        ch.write_length(254); // counter = 256 - 254 = 2
+        ch.write_frequency_high(0xC0); // トリガー + 長さ有効
+
+        assert!(ch.enabled);
+        ch.clock_length();
+        assert!(ch.enabled);
+        ch.clock_length();
+        assert!(!ch.enabled);
+    }
+
+    #[test]
+    fn test_wave_output_levels() {
+        let mut ch = WaveChannel::new();
+        ch.write_dac(0x80);
+        ch.enabled = true;
+        ch.sample_buffer = 0x0C; // サンプル値12
+
+        ch.write_output_level(0x20); // 100%
+        assert_eq!(ch.output(), 12);
+
+        ch.write_output_level(0x40); // 50%
+        assert_eq!(ch.output(), 6);
+
+        ch.write_output_level(0x60); // 25%
+        assert_eq!(ch.output(), 3);
+
+        ch.write_output_level(0x00); // 無音
+        assert_eq!(ch.output(), 0);
+    }
+
+    #[test]
+    fn test_wave_disabled_output() {
+        let ch = WaveChannel::new();
+        assert_eq!(ch.output(), 0);
+        assert_eq!(ch.dac_output(), 0.0);
+    }
+}

--- a/src/cartridge.rs
+++ b/src/cartridge.rs
@@ -14,6 +14,19 @@
 //   0x01: MBC1
 //   0x02: MBC1+RAM
 //   0x03: MBC1+RAM+BATTERY
+//   0x05: MBC2
+//   0x06: MBC2+BATTERY
+//   0x0F: MBC3+TIMER+BATTERY
+//   0x10: MBC3+TIMER+RAM+BATTERY
+//   0x11: MBC3
+//   0x12: MBC3+RAM
+//   0x13: MBC3+RAM+BATTERY
+//   0x19: MBC5
+//   0x1A: MBC5+RAM
+//   0x1B: MBC5+RAM+BATTERY
+//   0x1C: MBC5+RUMBLE
+//   0x1D: MBC5+RUMBLE+RAM
+//   0x1E: MBC5+RUMBLE+RAM+BATTERY
 
 /// カートリッジタイプ
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -22,6 +35,19 @@ pub enum CartridgeType {
     Mbc1,
     Mbc1Ram,
     Mbc1RamBattery,
+    Mbc2,
+    Mbc2Battery,
+    Mbc3TimerBattery,
+    Mbc3TimerRamBattery,
+    Mbc3,
+    Mbc3Ram,
+    Mbc3RamBattery,
+    Mbc5,
+    Mbc5Ram,
+    Mbc5RamBattery,
+    Mbc5Rumble,
+    Mbc5RumbleRam,
+    Mbc5RumbleRamBattery,
     Unknown(u8),
 }
 
@@ -32,17 +58,63 @@ impl CartridgeType {
             0x01 => CartridgeType::Mbc1,
             0x02 => CartridgeType::Mbc1Ram,
             0x03 => CartridgeType::Mbc1RamBattery,
+            0x05 => CartridgeType::Mbc2,
+            0x06 => CartridgeType::Mbc2Battery,
+            0x0F => CartridgeType::Mbc3TimerBattery,
+            0x10 => CartridgeType::Mbc3TimerRamBattery,
+            0x11 => CartridgeType::Mbc3,
+            0x12 => CartridgeType::Mbc3Ram,
+            0x13 => CartridgeType::Mbc3RamBattery,
+            0x19 => CartridgeType::Mbc5,
+            0x1A => CartridgeType::Mbc5Ram,
+            0x1B => CartridgeType::Mbc5RamBattery,
+            0x1C => CartridgeType::Mbc5Rumble,
+            0x1D => CartridgeType::Mbc5RumbleRam,
+            0x1E => CartridgeType::Mbc5RumbleRamBattery,
             other => CartridgeType::Unknown(other),
         }
     }
 
-    fn has_mbc1(&self) -> bool {
-        matches!(self, CartridgeType::Mbc1 | CartridgeType::Mbc1Ram | CartridgeType::Mbc1RamBattery)
+    /// MBCコントローラの種別を返す
+    fn mbc_kind(&self) -> MbcKind {
+        match self {
+            CartridgeType::RomOnly => MbcKind::None,
+            CartridgeType::Mbc1 | CartridgeType::Mbc1Ram | CartridgeType::Mbc1RamBattery => MbcKind::Mbc1,
+            CartridgeType::Mbc2 | CartridgeType::Mbc2Battery => MbcKind::Mbc2,
+            CartridgeType::Mbc3 | CartridgeType::Mbc3Ram | CartridgeType::Mbc3RamBattery
+            | CartridgeType::Mbc3TimerBattery | CartridgeType::Mbc3TimerRamBattery => MbcKind::Mbc3,
+            CartridgeType::Mbc5 | CartridgeType::Mbc5Ram | CartridgeType::Mbc5RamBattery
+            | CartridgeType::Mbc5Rumble | CartridgeType::Mbc5RumbleRam | CartridgeType::Mbc5RumbleRamBattery => MbcKind::Mbc5,
+            CartridgeType::Unknown(_) => MbcKind::None,
+        }
     }
 
     fn has_ram(&self) -> bool {
-        matches!(self, CartridgeType::Mbc1Ram | CartridgeType::Mbc1RamBattery)
+        matches!(self,
+            CartridgeType::Mbc1Ram | CartridgeType::Mbc1RamBattery
+            | CartridgeType::Mbc2 | CartridgeType::Mbc2Battery
+            | CartridgeType::Mbc3Ram | CartridgeType::Mbc3RamBattery
+            | CartridgeType::Mbc3TimerRamBattery
+            | CartridgeType::Mbc5Ram | CartridgeType::Mbc5RamBattery
+            | CartridgeType::Mbc5RumbleRam | CartridgeType::Mbc5RumbleRamBattery
+        )
     }
+
+    fn has_timer(&self) -> bool {
+        matches!(self,
+            CartridgeType::Mbc3TimerBattery | CartridgeType::Mbc3TimerRamBattery
+        )
+    }
+}
+
+/// MBCコントローラ種別
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum MbcKind {
+    None,
+    Mbc1,
+    Mbc2,
+    Mbc3,
+    Mbc5,
 }
 
 /// ROMサイズ (バンク数)
@@ -90,6 +162,71 @@ enum Mbc1Mode {
     Ram,  // モード1: RAM バンキング
 }
 
+/// MBC3 RTCレジスタ
+#[derive(Debug, Clone)]
+struct RtcRegisters {
+    /// 秒 (0-59)
+    seconds: u8,
+    /// 分 (0-59)
+    minutes: u8,
+    /// 時 (0-23)
+    hours: u8,
+    /// 日 下位8ビット
+    days_low: u8,
+    /// 日 上位ビット + 制御フラグ
+    /// Bit 0: 日カウンタ上位ビット (bit8)
+    /// Bit 6: 停止フラグ (0=動作中, 1=停止)
+    /// Bit 7: 日カウンタオーバーフロー
+    days_high: u8,
+}
+
+impl RtcRegisters {
+    fn new() -> Self {
+        Self {
+            seconds: 0,
+            minutes: 0,
+            hours: 0,
+            days_low: 0,
+            days_high: 0,
+        }
+    }
+
+    /// RTCを1秒進める
+    fn tick_second(&mut self) {
+        // 停止中は進めない
+        if self.days_high & 0x40 != 0 {
+            return;
+        }
+
+        self.seconds += 1;
+        if self.seconds >= 60 {
+            self.seconds = 0;
+            self.minutes += 1;
+            if self.minutes >= 60 {
+                self.minutes = 0;
+                self.hours += 1;
+                if self.hours >= 24 {
+                    self.hours = 0;
+                    let days = self.day_counter() + 1;
+                    self.days_low = days as u8;
+                    if days > 0x1FF {
+                        // オーバーフロー
+                        self.days_high = (self.days_high & 0xFE) | 0x80; // bit7=1, bit0=0
+                        self.days_low = 0;
+                    } else {
+                        self.days_high = (self.days_high & 0xFE) | ((days >> 8) as u8 & 0x01);
+                    }
+                }
+            }
+        }
+    }
+
+    /// 日カウンタ値 (0-511)
+    fn day_counter(&self) -> u16 {
+        self.days_low as u16 | ((self.days_high as u16 & 0x01) << 8)
+    }
+}
+
 /// カートリッジ
 pub struct Cartridge {
     /// ROMデータ
@@ -102,13 +239,28 @@ pub struct Cartridge {
     // MBC1レジスタ
     /// RAM有効フラグ
     ram_enabled: bool,
-    /// ROMバンク番号 (下位5bit)
-    rom_bank: u8,
+    /// ROMバンク番号 (下位5bit for MBC1, 4bit for MBC2, 7bit for MBC3, 9bit for MBC5)
+    rom_bank: u16,
     /// RAM バンク番号 / ROMバンク上位2bit
     ram_bank: u8,
-    /// バンキングモード
+    /// MBC1バンキングモード
     banking_mode: Mbc1Mode,
+
+    // MBC3 RTC
+    /// RTCレジスタ (現在値)
+    rtc: RtcRegisters,
+    /// RTCレジスタ (ラッチ値)
+    rtc_latched: RtcRegisters,
+    /// RTCラッチ前回値 (0x00→0x01のシーケンスで検出)
+    rtc_latch_pending: bool,
+    /// RTCマッピング (0x08-0x0C でRAMの代わりにRTCレジスタを選択)
+    rtc_mapped: bool,
+    /// RTC秒カウンタ (CPUサイクル→秒への変換)
+    rtc_cycle_counter: u32,
 }
+
+/// CPUサイクル→1秒 (4,194,304サイクル)
+const CYCLES_PER_SECOND: u32 = 4_194_304;
 
 impl Cartridge {
     /// ROMデータからカートリッジを作成
@@ -120,11 +272,16 @@ impl Cartridge {
         let header = Self::parse_header(&rom_data);
         let ram_size = header.ram_size;
 
-        // MBC1+RAMの場合、最低8KBのRAMを確保
-        let actual_ram_size = if header.cartridge_type.has_ram() && ram_size == 0 {
-            8 * 1024
-        } else {
-            ram_size
+        // MBC種別に応じたRAMサイズ決定
+        let actual_ram_size = match header.cartridge_type.mbc_kind() {
+            MbcKind::Mbc2 => 512, // MBC2: 512×4ビット内蔵RAM
+            _ => {
+                if header.cartridge_type.has_ram() && ram_size == 0 {
+                    8 * 1024 // 最低8KB
+                } else {
+                    ram_size
+                }
+            }
         };
 
         Ok(Self {
@@ -135,6 +292,11 @@ impl Cartridge {
             rom_bank: 1,
             ram_bank: 0,
             banking_mode: Mbc1Mode::Rom,
+            rtc: RtcRegisters::new(),
+            rtc_latched: RtcRegisters::new(),
+            rtc_latch_pending: false,
+            rtc_mapped: false,
+            rtc_cycle_counter: 0,
         })
     }
 
@@ -159,6 +321,11 @@ impl Cartridge {
             rom_bank: 1,
             ram_bank: 0,
             banking_mode: Mbc1Mode::Rom,
+            rtc: RtcRegisters::new(),
+            rtc_latched: RtcRegisters::new(),
+            rtc_latch_pending: false,
+            rtc_mapped: false,
+            rtc_cycle_counter: 0,
         }
     }
 
@@ -183,59 +350,103 @@ impl Cartridge {
         }
     }
 
+    /// カートリッジを1 CPUサイクル進める (RTC用)
+    pub fn tick(&mut self) {
+        if !self.header.cartridge_type.has_timer() {
+            return;
+        }
+
+        self.rtc_cycle_counter += 1;
+        if self.rtc_cycle_counter >= CYCLES_PER_SECOND {
+            self.rtc_cycle_counter = 0;
+            self.rtc.tick_second();
+        }
+    }
+
     /// ROM領域の読み取り (0x0000-0x7FFF)
     pub fn read_rom(&self, addr: u16) -> u8 {
-        match addr {
-            // Bank 0 (0x0000-0x3FFF) — 常にバンク0
-            0x0000..=0x3FFF => {
-                if self.header.cartridge_type == CartridgeType::RomOnly {
-                    self.rom.get(addr as usize).copied().unwrap_or(0xFF)
-                } else {
-                    // MBC1 モード1ではBank 0の代わりに0x20/0x40/0x60バンク
-                    let bank = if self.banking_mode == Mbc1Mode::Ram {
-                        (self.ram_bank as usize) << 5
-                    } else {
-                        0
-                    };
-                    let offset = bank * 0x4000 + addr as usize;
-                    self.rom.get(offset).copied().unwrap_or(0xFF)
-                }
-            }
-            // Bank N (0x4000-0x7FFF)
-            0x4000..=0x7FFF => {
-                if self.header.cartridge_type == CartridgeType::RomOnly {
-                    self.rom.get(addr as usize).copied().unwrap_or(0xFF)
-                } else {
-                    let bank = self.effective_rom_bank();
-                    let offset = bank * 0x4000 + (addr as usize - 0x4000);
-                    self.rom.get(offset).copied().unwrap_or(0xFF)
-                }
-            }
-            _ => 0xFF,
+        match self.header.cartridge_type.mbc_kind() {
+            MbcKind::None => self.read_rom_none(addr),
+            MbcKind::Mbc1 => self.read_rom_mbc1(addr),
+            MbcKind::Mbc2 => self.read_rom_mbc2(addr),
+            MbcKind::Mbc3 => self.read_rom_mbc3(addr),
+            MbcKind::Mbc5 => self.read_rom_mbc5(addr),
         }
     }
 
     /// ROM領域への書き込み (MBCレジスタ操作)
     pub fn write_rom(&mut self, addr: u16, value: u8) {
-        if !self.header.cartridge_type.has_mbc1() {
-            return; // ROM ONLYは書き込み不可
+        match self.header.cartridge_type.mbc_kind() {
+            MbcKind::None => {} // ROM ONLYは書き込み不可
+            MbcKind::Mbc1 => self.write_rom_mbc1(addr, value),
+            MbcKind::Mbc2 => self.write_rom_mbc2(addr, value),
+            MbcKind::Mbc3 => self.write_rom_mbc3(addr, value),
+            MbcKind::Mbc5 => self.write_rom_mbc5(addr, value),
         }
+    }
 
+    /// 外部RAM読み取り (0xA000-0xBFFF)
+    pub fn read_ram(&self, addr: u16) -> u8 {
+        match self.header.cartridge_type.mbc_kind() {
+            MbcKind::None => 0xFF,
+            MbcKind::Mbc1 => self.read_ram_mbc1(addr),
+            MbcKind::Mbc2 => self.read_ram_mbc2(addr),
+            MbcKind::Mbc3 => self.read_ram_mbc3(addr),
+            MbcKind::Mbc5 => self.read_ram_mbc5(addr),
+        }
+    }
+
+    /// 外部RAM書き込み (0xA000-0xBFFF)
+    pub fn write_ram(&mut self, addr: u16, value: u8) {
+        match self.header.cartridge_type.mbc_kind() {
+            MbcKind::None => {}
+            MbcKind::Mbc1 => self.write_ram_mbc1(addr, value),
+            MbcKind::Mbc2 => self.write_ram_mbc2(addr, value),
+            MbcKind::Mbc3 => self.write_ram_mbc3(addr, value),
+            MbcKind::Mbc5 => self.write_ram_mbc5(addr, value),
+        }
+    }
+
+    // ===== ROM ONLY =====
+
+    fn read_rom_none(&self, addr: u16) -> u8 {
+        self.rom.get(addr as usize).copied().unwrap_or(0xFF)
+    }
+
+    // ===== MBC1 =====
+
+    fn read_rom_mbc1(&self, addr: u16) -> u8 {
         match addr {
-            // RAM Enable (0x0000-0x1FFF)
+            0x0000..=0x3FFF => {
+                let bank = if self.banking_mode == Mbc1Mode::Ram {
+                    (self.ram_bank as usize) << 5
+                } else {
+                    0
+                };
+                let offset = bank * 0x4000 + addr as usize;
+                self.rom.get(offset).copied().unwrap_or(0xFF)
+            }
+            0x4000..=0x7FFF => {
+                let bank = self.effective_rom_bank_mbc1();
+                let offset = bank * 0x4000 + (addr as usize - 0x4000);
+                self.rom.get(offset).copied().unwrap_or(0xFF)
+            }
+            _ => 0xFF,
+        }
+    }
+
+    fn write_rom_mbc1(&mut self, addr: u16, value: u8) {
+        match addr {
             0x0000..=0x1FFF => {
                 self.ram_enabled = (value & 0x0F) == 0x0A;
             }
-            // ROM Bank Number (0x2000-0x3FFF) — 下位5bit
             0x2000..=0x3FFF => {
                 let bank = value & 0x1F;
-                self.rom_bank = if bank == 0 { 1 } else { bank };
+                self.rom_bank = if bank == 0 { 1 } else { bank as u16 };
             }
-            // RAM Bank Number / Upper ROM Bank (0x4000-0x5FFF)
             0x4000..=0x5FFF => {
                 self.ram_bank = value & 0x03;
             }
-            // Banking Mode (0x6000-0x7FFF)
             0x6000..=0x7FFF => {
                 self.banking_mode = if value & 0x01 == 0 {
                     Mbc1Mode::Rom
@@ -247,12 +458,10 @@ impl Cartridge {
         }
     }
 
-    /// 外部RAM読み取り (0xA000-0xBFFF)
-    pub fn read_ram(&self, addr: u16) -> u8 {
+    fn read_ram_mbc1(&self, addr: u16) -> u8 {
         if !self.ram_enabled || self.ram.is_empty() {
             return 0xFF;
         }
-
         let bank = if self.banking_mode == Mbc1Mode::Ram {
             self.ram_bank as usize
         } else {
@@ -262,12 +471,10 @@ impl Cartridge {
         self.ram.get(offset).copied().unwrap_or(0xFF)
     }
 
-    /// 外部RAM書き込み (0xA000-0xBFFF)
-    pub fn write_ram(&mut self, addr: u16, value: u8) {
+    fn write_ram_mbc1(&mut self, addr: u16, value: u8) {
         if !self.ram_enabled || self.ram.is_empty() {
             return;
         }
-
         let bank = if self.banking_mode == Mbc1Mode::Ram {
             self.ram_bank as usize
         } else {
@@ -279,10 +486,226 @@ impl Cartridge {
         }
     }
 
-    /// 実効ROMバンク番号を計算
-    fn effective_rom_bank(&self) -> usize {
+    fn effective_rom_bank_mbc1(&self) -> usize {
         let bank = (self.ram_bank as usize) << 5 | (self.rom_bank as usize);
         bank % self.header.rom_banks
+    }
+
+    // ===== MBC2 =====
+
+    fn read_rom_mbc2(&self, addr: u16) -> u8 {
+        match addr {
+            0x0000..=0x3FFF => {
+                self.rom.get(addr as usize).copied().unwrap_or(0xFF)
+            }
+            0x4000..=0x7FFF => {
+                let bank = (self.rom_bank as usize) % self.header.rom_banks;
+                let offset = bank * 0x4000 + (addr as usize - 0x4000);
+                self.rom.get(offset).copied().unwrap_or(0xFF)
+            }
+            _ => 0xFF,
+        }
+    }
+
+    fn write_rom_mbc2(&mut self, addr: u16, value: u8) {
+        match addr {
+            // RAM有効/無効 — アドレスのbit8が0
+            0x0000..=0x3FFF => {
+                if addr & 0x0100 == 0 {
+                    // RAM Enable/Disable
+                    self.ram_enabled = (value & 0x0F) == 0x0A;
+                } else {
+                    // ROM Bank Number (下位4ビット)
+                    let bank = value & 0x0F;
+                    self.rom_bank = if bank == 0 { 1 } else { bank as u16 };
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn read_ram_mbc2(&self, addr: u16) -> u8 {
+        if !self.ram_enabled || self.ram.is_empty() {
+            return 0xFF;
+        }
+        // MBC2 RAM: 512×4ビット、アドレスの下位9ビットでアクセス
+        let offset = (addr as usize - 0xA000) & 0x01FF;
+        if offset < self.ram.len() {
+            self.ram[offset] | 0xF0 // 上位4ビットは常に1
+        } else {
+            0xFF
+        }
+    }
+
+    fn write_ram_mbc2(&mut self, addr: u16, value: u8) {
+        if !self.ram_enabled || self.ram.is_empty() {
+            return;
+        }
+        let offset = (addr as usize - 0xA000) & 0x01FF;
+        if offset < self.ram.len() {
+            self.ram[offset] = value & 0x0F; // 下位4ビットのみ
+        }
+    }
+
+    // ===== MBC3 =====
+
+    fn read_rom_mbc3(&self, addr: u16) -> u8 {
+        match addr {
+            0x0000..=0x3FFF => {
+                self.rom.get(addr as usize).copied().unwrap_or(0xFF)
+            }
+            0x4000..=0x7FFF => {
+                let bank = (self.rom_bank as usize) % self.header.rom_banks;
+                let offset = bank * 0x4000 + (addr as usize - 0x4000);
+                self.rom.get(offset).copied().unwrap_or(0xFF)
+            }
+            _ => 0xFF,
+        }
+    }
+
+    fn write_rom_mbc3(&mut self, addr: u16, value: u8) {
+        match addr {
+            // RAM/RTC有効
+            0x0000..=0x1FFF => {
+                self.ram_enabled = (value & 0x0F) == 0x0A;
+            }
+            // ROMバンク番号 (7ビット, 0→1にリダイレクト)
+            0x2000..=0x3FFF => {
+                let bank = value & 0x7F;
+                self.rom_bank = if bank == 0 { 1 } else { bank as u16 };
+            }
+            // RAMバンク番号 / RTCレジスタ選択
+            0x4000..=0x5FFF => {
+                self.ram_bank = value;
+                self.rtc_mapped = value >= 0x08 && value <= 0x0C;
+            }
+            // RTCラッチ
+            0x6000..=0x7FFF => {
+                if value == 0x00 {
+                    self.rtc_latch_pending = true;
+                } else if value == 0x01 && self.rtc_latch_pending {
+                    // ラッチ: 現在のRTC値をコピー
+                    self.rtc_latched = self.rtc.clone();
+                    self.rtc_latch_pending = false;
+                } else {
+                    self.rtc_latch_pending = false;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn read_ram_mbc3(&self, addr: u16) -> u8 {
+        if !self.ram_enabled {
+            return 0xFF;
+        }
+
+        // RTCレジスタマッピング
+        if self.rtc_mapped {
+            return match self.ram_bank {
+                0x08 => self.rtc_latched.seconds,
+                0x09 => self.rtc_latched.minutes,
+                0x0A => self.rtc_latched.hours,
+                0x0B => self.rtc_latched.days_low,
+                0x0C => self.rtc_latched.days_high,
+                _ => 0xFF,
+            };
+        }
+
+        // 通常RAM
+        if self.ram.is_empty() {
+            return 0xFF;
+        }
+        let bank = (self.ram_bank as usize) & 0x03;
+        let offset = bank * 0x2000 + (addr as usize - 0xA000);
+        self.ram.get(offset).copied().unwrap_or(0xFF)
+    }
+
+    fn write_ram_mbc3(&mut self, addr: u16, value: u8) {
+        if !self.ram_enabled {
+            return;
+        }
+
+        // RTCレジスタ書き込み
+        if self.rtc_mapped {
+            match self.ram_bank {
+                0x08 => self.rtc.seconds = value & 0x3F,
+                0x09 => self.rtc.minutes = value & 0x3F,
+                0x0A => self.rtc.hours = value & 0x1F,
+                0x0B => self.rtc.days_low = value,
+                0x0C => self.rtc.days_high = value & 0xC1, // bit0,6,7のみ
+                _ => {}
+            }
+            return;
+        }
+
+        // 通常RAM
+        if self.ram.is_empty() {
+            return;
+        }
+        let bank = (self.ram_bank as usize) & 0x03;
+        let offset = bank * 0x2000 + (addr as usize - 0xA000);
+        if offset < self.ram.len() {
+            self.ram[offset] = value;
+        }
+    }
+
+    // ===== MBC5 =====
+
+    fn read_rom_mbc5(&self, addr: u16) -> u8 {
+        match addr {
+            0x0000..=0x3FFF => {
+                self.rom.get(addr as usize).copied().unwrap_or(0xFF)
+            }
+            0x4000..=0x7FFF => {
+                let bank = (self.rom_bank as usize) % self.header.rom_banks;
+                let offset = bank * 0x4000 + (addr as usize - 0x4000);
+                self.rom.get(offset).copied().unwrap_or(0xFF)
+            }
+            _ => 0xFF,
+        }
+    }
+
+    fn write_rom_mbc5(&mut self, addr: u16, value: u8) {
+        match addr {
+            // RAM有効
+            0x0000..=0x1FFF => {
+                self.ram_enabled = (value & 0x0F) == 0x0A;
+            }
+            // ROMバンク番号 下位8ビット
+            0x2000..=0x2FFF => {
+                self.rom_bank = (self.rom_bank & 0x100) | value as u16;
+            }
+            // ROMバンク番号 上位1ビット (bit8)
+            0x3000..=0x3FFF => {
+                self.rom_bank = (self.rom_bank & 0x0FF) | ((value as u16 & 0x01) << 8);
+            }
+            // RAMバンク番号 (0-15)
+            0x4000..=0x5FFF => {
+                self.ram_bank = value & 0x0F;
+            }
+            _ => {}
+        }
+    }
+
+    fn read_ram_mbc5(&self, addr: u16) -> u8 {
+        if !self.ram_enabled || self.ram.is_empty() {
+            return 0xFF;
+        }
+        let bank = self.ram_bank as usize;
+        let offset = bank * 0x2000 + (addr as usize - 0xA000);
+        self.ram.get(offset).copied().unwrap_or(0xFF)
+    }
+
+    fn write_ram_mbc5(&mut self, addr: u16, value: u8) {
+        if !self.ram_enabled || self.ram.is_empty() {
+            return;
+        }
+        let bank = self.ram_bank as usize;
+        let offset = bank * 0x2000 + (addr as usize - 0xA000);
+        if offset < self.ram.len() {
+            self.ram[offset] = value;
+        }
     }
 }
 
@@ -306,6 +729,15 @@ mod tests {
         rom
     }
 
+    fn create_test_rom_with_ram(size: usize, cart_type: u8, rom_size_byte: u8, ram_size_byte: u8) -> Vec<u8> {
+        let mut rom = create_test_rom(size, cart_type);
+        rom[0x0148] = rom_size_byte;
+        rom[0x0149] = ram_size_byte;
+        rom
+    }
+
+    // ===== ROM ONLY テスト =====
+
     #[test]
     fn test_rom_only_cartridge() {
         let mut rom = create_test_rom(0x8000, 0x00);
@@ -326,6 +758,8 @@ mod tests {
         assert_eq!(cart.header.cartridge_type, CartridgeType::Mbc1);
         assert_eq!(cart.header.rom_banks, 2);
     }
+
+    // ===== MBC1 テスト =====
 
     #[test]
     fn test_mbc1_rom_bank_switching() {
@@ -354,7 +788,6 @@ mod tests {
 
     #[test]
     fn test_mbc1_bank0_redirect() {
-        // バンク0への書き込みは自動的にバンク1にリダイレクト
         let rom = create_test_rom(0x8000, 0x01);
         let mut cart = Cartridge::new(rom).unwrap();
         cart.write_rom(0x2000, 0x00); // バンク0を指定
@@ -394,5 +827,308 @@ mod tests {
         assert_eq!(cart.header.cartridge_type, CartridgeType::RomOnly);
         // 32KBにパディングされている
         assert_eq!(cart.rom.len(), 0x8000);
+    }
+
+    // ===== MBC2 テスト =====
+
+    #[test]
+    fn test_mbc2_rom_bank_switching() {
+        let mut rom = create_test_rom(0x10000, 0x05); // MBC2
+        rom[0x0148] = 0x01; // 64KB
+
+        rom[0x4000] = 0x11; // Bank 1
+        rom[0x8000] = 0x22; // Bank 2
+        rom[0xC000] = 0x33; // Bank 3
+
+        let mut cart = Cartridge::new(rom).unwrap();
+
+        // デフォルトはバンク1
+        assert_eq!(cart.read_rom(0x4000), 0x11);
+
+        // バンク切り替え (bit8=1 のアドレス)
+        cart.write_rom(0x2100, 0x02);
+        assert_eq!(cart.read_rom(0x4000), 0x22);
+
+        cart.write_rom(0x2100, 0x03);
+        assert_eq!(cart.read_rom(0x4000), 0x33);
+    }
+
+    #[test]
+    fn test_mbc2_bank0_redirect() {
+        let rom = create_test_rom(0x8000, 0x05);
+        let mut cart = Cartridge::new(rom).unwrap();
+        cart.write_rom(0x2100, 0x00); // バンク0
+        assert_eq!(cart.rom_bank, 1); // バンク1にリダイレクト
+    }
+
+    #[test]
+    fn test_mbc2_ram() {
+        let rom = create_test_rom(0x8000, 0x05);
+        let mut cart = Cartridge::new(rom).unwrap();
+
+        // MBC2 RAMは512×4ビット
+        assert_eq!(cart.ram.len(), 512);
+
+        // RAM有効化 (bit8=0のアドレス)
+        cart.write_rom(0x0000, 0x0A);
+        assert!(cart.ram_enabled);
+
+        // 下位4ビットのみ書き込み可能
+        cart.write_ram(0xA000, 0xFF);
+        assert_eq!(cart.read_ram(0xA000) & 0x0F, 0x0F);
+        // 上位4ビットは読み取り時に1
+        assert_eq!(cart.read_ram(0xA000), 0xFF);
+
+        // 4ビットデータ確認
+        cart.write_ram(0xA001, 0x35);
+        assert_eq!(cart.read_ram(0xA001) & 0x0F, 0x05); // 下位4ビットのみ
+    }
+
+    #[test]
+    fn test_mbc2_ram_enable_address_bit8() {
+        let rom = create_test_rom(0x8000, 0x05);
+        let mut cart = Cartridge::new(rom).unwrap();
+
+        // bit8=1 のアドレス → ROMバンク番号
+        cart.write_rom(0x0100, 0x0A);
+        assert!(!cart.ram_enabled); // RAM有効化されない
+
+        // bit8=0 のアドレス → RAM有効化
+        cart.write_rom(0x0000, 0x0A);
+        assert!(cart.ram_enabled);
+    }
+
+    #[test]
+    fn test_mbc2_ram_wrapping() {
+        let rom = create_test_rom(0x8000, 0x05);
+        let mut cart = Cartridge::new(rom).unwrap();
+        cart.write_rom(0x0000, 0x0A); // RAM有効化
+
+        // 0xA200 は 0xA000と同じオフセット（下位9ビットでラップ）
+        cart.write_ram(0xA000, 0x07);
+        assert_eq!(cart.read_ram(0xA200) & 0x0F, 0x07); // 同じアドレスにラップ
+    }
+
+    // ===== MBC3 テスト =====
+
+    #[test]
+    fn test_mbc3_rom_bank_switching() {
+        let mut rom = create_test_rom_with_ram(0x20000, 0x13, 0x02, 0x03); // MBC3+RAM+BATTERY, 128KB ROM, 32KB RAM
+
+        rom[0x4000] = 0xAA; // Bank 1
+        rom[0x8000] = 0xBB; // Bank 2
+        rom[0x1C000] = 0xCC; // Bank 7
+
+        let mut cart = Cartridge::new(rom).unwrap();
+
+        assert_eq!(cart.read_rom(0x4000), 0xAA);
+
+        cart.write_rom(0x2000, 0x02);
+        assert_eq!(cart.read_rom(0x4000), 0xBB);
+
+        cart.write_rom(0x2000, 0x07);
+        assert_eq!(cart.read_rom(0x4000), 0xCC);
+    }
+
+    #[test]
+    fn test_mbc3_bank0_redirect() {
+        let rom = create_test_rom(0x8000, 0x11);
+        let mut cart = Cartridge::new(rom).unwrap();
+        cart.write_rom(0x2000, 0x00);
+        assert_eq!(cart.rom_bank, 1);
+    }
+
+    #[test]
+    fn test_mbc3_ram_banking() {
+        let rom = create_test_rom_with_ram(0x8000, 0x13, 0x00, 0x03); // 32KB RAM (4バンク)
+        let mut cart = Cartridge::new(rom).unwrap();
+        cart.write_rom(0x0000, 0x0A); // RAM有効化
+
+        // バンク0に書き込み
+        cart.write_rom(0x4000, 0x00);
+        cart.write_ram(0xA000, 0x11);
+
+        // バンク1に書き込み
+        cart.write_rom(0x4000, 0x01);
+        cart.write_ram(0xA000, 0x22);
+
+        // バンク0の読み取り
+        cart.write_rom(0x4000, 0x00);
+        assert_eq!(cart.read_ram(0xA000), 0x11);
+
+        // バンク1の読み取り
+        cart.write_rom(0x4000, 0x01);
+        assert_eq!(cart.read_ram(0xA000), 0x22);
+    }
+
+    #[test]
+    fn test_mbc3_rtc_latch() {
+        let rom = create_test_rom(0x8000, 0x0F); // MBC3+TIMER+BATTERY
+        let mut cart = Cartridge::new(rom).unwrap();
+        cart.write_rom(0x0000, 0x0A); // RAM/RTC有効化
+
+        // RTCに値をセット
+        cart.write_rom(0x4000, 0x08); // 秒レジスタ選択
+        cart.write_ram(0xA000, 30); // 30秒
+
+        cart.write_rom(0x4000, 0x09); // 分レジスタ
+        cart.write_ram(0xA000, 45); // 45分
+
+        // ラッチ実行 (0x00 → 0x01)
+        cart.write_rom(0x6000, 0x00);
+        cart.write_rom(0x6000, 0x01);
+
+        // ラッチされた値を読み取り
+        cart.write_rom(0x4000, 0x08);
+        assert_eq!(cart.read_ram(0xA000), 30);
+
+        cart.write_rom(0x4000, 0x09);
+        assert_eq!(cart.read_ram(0xA000), 45);
+    }
+
+    #[test]
+    fn test_mbc3_rtc_tick() {
+        let rom = create_test_rom(0x8000, 0x0F); // MBC3+TIMER+BATTERY
+        let mut cart = Cartridge::new(rom).unwrap();
+
+        // 1秒分のサイクルを進める
+        for _ in 0..CYCLES_PER_SECOND {
+            cart.tick();
+        }
+
+        // ラッチしてRTC値を確認
+        cart.write_rom(0x0000, 0x0A);
+        cart.write_rom(0x6000, 0x00);
+        cart.write_rom(0x6000, 0x01);
+
+        cart.write_rom(0x4000, 0x08);
+        assert_eq!(cart.read_ram(0xA000), 1); // 1秒経過
+    }
+
+    #[test]
+    fn test_mbc3_rtc_halt() {
+        let rom = create_test_rom(0x8000, 0x0F);
+        let mut cart = Cartridge::new(rom).unwrap();
+        cart.write_rom(0x0000, 0x0A);
+
+        // RTCを停止
+        cart.write_rom(0x4000, 0x0C); // days_high選択
+        cart.write_ram(0xA000, 0x40); // bit6=1: 停止
+
+        // サイクルを進めてもRTCは変化しない
+        for _ in 0..CYCLES_PER_SECOND * 2 {
+            cart.tick();
+        }
+
+        // ラッチして確認
+        cart.write_rom(0x6000, 0x00);
+        cart.write_rom(0x6000, 0x01);
+
+        cart.write_rom(0x4000, 0x08);
+        assert_eq!(cart.read_ram(0xA000), 0); // 0秒のまま
+    }
+
+    // ===== MBC5 テスト =====
+
+    #[test]
+    fn test_mbc5_rom_bank_switching() {
+        let mut rom = create_test_rom_with_ram(0x20000, 0x19, 0x02, 0x00); // MBC5, 128KB ROM
+
+        rom[0x4000] = 0x11; // Bank 1
+        rom[0x8000] = 0x22; // Bank 2
+        rom[0xC000] = 0x33; // Bank 3
+
+        let mut cart = Cartridge::new(rom).unwrap();
+
+        assert_eq!(cart.read_rom(0x4000), 0x11);
+
+        cart.write_rom(0x2000, 0x02);
+        assert_eq!(cart.read_rom(0x4000), 0x22);
+
+        cart.write_rom(0x2000, 0x03);
+        assert_eq!(cart.read_rom(0x4000), 0x33);
+    }
+
+    #[test]
+    fn test_mbc5_bank0_allowed() {
+        let mut rom = create_test_rom(0x10000, 0x19);
+        rom[0x0148] = 0x01; // 64KB
+        rom[0x0000] = 0xAA; // Bank 0のデータ
+
+        let mut cart = Cartridge::new(rom).unwrap();
+
+        // MBC5ではバンク0を選択可能（MBC1と異なる）
+        cart.write_rom(0x2000, 0x00);
+        assert_eq!(cart.rom_bank, 0); // バンク0のまま
+        // Bank 0のデータ（0x0000-0x3FFFと同じ）
+        assert_eq!(cart.read_rom(0x4000), cart.read_rom(0x0000));
+    }
+
+    #[test]
+    fn test_mbc5_9bit_rom_bank() {
+        let rom = create_test_rom_with_ram(0x80000, 0x19, 0x04, 0x00); // MBC5, 512KB ROM (32バンク)
+
+        // バンク番号の上位ビットテスト
+        let mut cart = Cartridge::new(rom).unwrap();
+
+        // 下位8ビット
+        cart.write_rom(0x2000, 0xFF);
+        assert_eq!(cart.rom_bank & 0xFF, 0xFF);
+
+        // 上位1ビット
+        cart.write_rom(0x3000, 0x01);
+        assert_eq!(cart.rom_bank, 0x1FF); // 9ビット
+    }
+
+    #[test]
+    fn test_mbc5_ram() {
+        let rom = create_test_rom_with_ram(0x8000, 0x1A, 0x00, 0x02); // MBC5+RAM, 8KB RAM
+        let mut cart = Cartridge::new(rom).unwrap();
+
+        cart.write_rom(0x0000, 0x0A); // RAM有効化
+        cart.write_ram(0xA000, 0x42);
+        assert_eq!(cart.read_ram(0xA000), 0x42);
+    }
+
+    #[test]
+    fn test_mbc5_ram_banking() {
+        let rom = create_test_rom_with_ram(0x8000, 0x1A, 0x00, 0x03); // 32KB RAM (4バンク)
+        let mut cart = Cartridge::new(rom).unwrap();
+        cart.write_rom(0x0000, 0x0A);
+
+        // バンク0
+        cart.write_rom(0x4000, 0x00);
+        cart.write_ram(0xA000, 0x11);
+
+        // バンク1
+        cart.write_rom(0x4000, 0x01);
+        cart.write_ram(0xA000, 0x22);
+
+        // バンク0の読み取り
+        cart.write_rom(0x4000, 0x00);
+        assert_eq!(cart.read_ram(0xA000), 0x11);
+
+        // バンク1の読み取り
+        cart.write_rom(0x4000, 0x01);
+        assert_eq!(cart.read_ram(0xA000), 0x22);
+    }
+
+    // ===== カートリッジタイプ検出テスト =====
+
+    #[test]
+    fn test_cartridge_type_detection() {
+        assert_eq!(CartridgeType::from_byte(0x00).mbc_kind(), MbcKind::None);
+        assert_eq!(CartridgeType::from_byte(0x01).mbc_kind(), MbcKind::Mbc1);
+        assert_eq!(CartridgeType::from_byte(0x05).mbc_kind(), MbcKind::Mbc2);
+        assert_eq!(CartridgeType::from_byte(0x13).mbc_kind(), MbcKind::Mbc3);
+        assert_eq!(CartridgeType::from_byte(0x19).mbc_kind(), MbcKind::Mbc5);
+    }
+
+    #[test]
+    fn test_cartridge_has_timer() {
+        assert!(CartridgeType::Mbc3TimerBattery.has_timer());
+        assert!(CartridgeType::Mbc3TimerRamBattery.has_timer());
+        assert!(!CartridgeType::Mbc3.has_timer());
+        assert!(!CartridgeType::Mbc1.has_timer());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,8 @@ mod simple_display;  // 簡易ASCII表示
 mod joypad;          // ジョイパッド入力
 mod dma;             // DMA転送コントローラ
 mod cartridge;       // カートリッジ・MBCシステム
+mod serial;          // シリアル通信
+mod apu;             // APU（音声処理ユニット）
 
 #[cfg(feature = "with_sdl")]
 mod lcd;             // LCDディスプレイ

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -1,0 +1,184 @@
+// src/serial.rs
+// GameBoy シリアル通信コントローラ
+//
+// SB (0xFF01): シリアル転送データ — 8ビットデータレジスタ
+// SC (0xFF02): シリアル転送制御
+//   Bit 7: 転送開始フラグ (1=転送要求/実行中)
+//   Bit 1: クロック速度 (CGBのみ、DMGでは無視)
+//   Bit 0: シフトクロック (0=外部クロック, 1=内部クロック)
+//
+// 内部クロック使用時: 8192Hz (512 CPUサイクル/bit、4096サイクル/バイト)
+// 転送完了時(8ビットシフト後): SC bit7をクリアし、シリアル割り込みを要求
+
+/// シリアル通信コントローラ
+pub struct Serial {
+    /// シリアル転送データ (SB: 0xFF01)
+    pub sb: u8,
+    /// シリアル転送制御 (SC: 0xFF02)
+    pub sc: u8,
+    /// 転送サイクルカウンタ
+    transfer_counter: u16,
+    /// 転送ビットカウンタ
+    bit_counter: u8,
+    /// 割り込み要求フラグ
+    pub interrupt_request: bool,
+}
+
+/// 内部クロック: 1ビットあたり512 CPUサイクル (4,194,304 Hz / 8192 Hz)
+const CYCLES_PER_BIT: u16 = 512;
+
+impl Serial {
+    pub fn new() -> Self {
+        Self {
+            sb: 0x00,
+            sc: 0x7E, // 初期値: 転送停止、未使用ビットは1
+            transfer_counter: 0,
+            bit_counter: 0,
+            interrupt_request: false,
+        }
+    }
+
+    /// SBレジスタの読み取り
+    pub fn read_sb(&self) -> u8 {
+        self.sb
+    }
+
+    /// SBレジスタへの書き込み
+    pub fn write_sb(&mut self, value: u8) {
+        self.sb = value;
+    }
+
+    /// SCレジスタの読み取り (未使用ビットは1)
+    pub fn read_sc(&self) -> u8 {
+        self.sc | 0x7E // Bit 1-6は常に1 (DMG)
+    }
+
+    /// SCレジスタへの書き込み
+    pub fn write_sc(&mut self, value: u8) {
+        self.sc = value;
+        // 転送開始 (bit7=1, bit0=1: 内部クロック)
+        if value & 0x81 == 0x81 {
+            self.transfer_counter = 0;
+            self.bit_counter = 0;
+        }
+    }
+
+    /// 転送がアクティブかどうか
+    pub fn is_transferring(&self) -> bool {
+        self.sc & 0x80 != 0 && self.sc & 0x01 != 0
+    }
+
+    /// シリアル通信を1サイクル進める
+    pub fn tick(&mut self) {
+        if !self.is_transferring() {
+            return;
+        }
+
+        self.transfer_counter += 1;
+
+        if self.transfer_counter >= CYCLES_PER_BIT {
+            self.transfer_counter = 0;
+            self.bit_counter += 1;
+
+            // データをシフト（外部デバイスなし→0xFFを受信）
+            self.sb = (self.sb << 1) | 0x01;
+
+            if self.bit_counter >= 8 {
+                // 転送完了
+                self.sc &= !0x80; // 転送フラグをクリア
+                self.bit_counter = 0;
+                self.interrupt_request = true;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_serial_creation() {
+        let serial = Serial::new();
+        assert_eq!(serial.read_sb(), 0x00);
+        assert_eq!(serial.read_sc() & 0x81, 0x00); // 転送停止、外部クロック
+        assert!(!serial.is_transferring());
+        assert!(!serial.interrupt_request);
+    }
+
+    #[test]
+    fn test_serial_sb_read_write() {
+        let mut serial = Serial::new();
+        serial.write_sb(0x42);
+        assert_eq!(serial.read_sb(), 0x42);
+        serial.write_sb(0xFF);
+        assert_eq!(serial.read_sb(), 0xFF);
+    }
+
+    #[test]
+    fn test_serial_sc_unused_bits() {
+        let serial = Serial::new();
+        // SCの未使用ビット(1-6)は読み取り時に1
+        assert_eq!(serial.read_sc() & 0x7E, 0x7E);
+    }
+
+    #[test]
+    fn test_serial_transfer_start() {
+        let mut serial = Serial::new();
+        serial.write_sb(0xAB);
+        serial.write_sc(0x81); // 転送開始（内部クロック）
+        assert!(serial.is_transferring());
+    }
+
+    #[test]
+    fn test_serial_transfer_external_clock_no_transfer() {
+        let mut serial = Serial::new();
+        serial.write_sc(0x80); // 転送開始だが外部クロック
+        // 外部クロックでは内部tickで進まない
+        assert!(!serial.is_transferring());
+    }
+
+    #[test]
+    fn test_serial_transfer_complete() {
+        let mut serial = Serial::new();
+        serial.write_sb(0xAB);
+        serial.write_sc(0x81); // 内部クロックで転送開始
+
+        // 8ビット転送 = 8 × 512 = 4096サイクル
+        for _ in 0..4096 {
+            serial.tick();
+        }
+
+        // 転送完了: SC bit7クリア、割り込み要求
+        assert_eq!(serial.read_sc() & 0x80, 0x00);
+        assert!(serial.interrupt_request);
+    }
+
+    #[test]
+    fn test_serial_receive_ff_without_connection() {
+        let mut serial = Serial::new();
+        serial.write_sb(0x00);
+        serial.write_sc(0x81);
+
+        // 接続なし → 全ビット1を受信
+        for _ in 0..4096 {
+            serial.tick();
+        }
+
+        assert_eq!(serial.read_sb(), 0xFF);
+    }
+
+    #[test]
+    fn test_serial_inactive_tick() {
+        let mut serial = Serial::new();
+        serial.write_sb(0x42);
+
+        // 転送を開始していない場合、tickは何もしない
+        for _ in 0..5000 {
+            serial.tick();
+        }
+
+        assert_eq!(serial.read_sb(), 0x42);
+        assert!(!serial.interrupt_request);
+    }
+}


### PR DESCRIPTION
APU: 4チャンネル音声処理（パルス×2+ウェーブ+ノイズ）、512Hzフレームシーケンサ、
スイープ/エンベロープ/長さカウンタ、ステレオミキサー、44.1kHzサンプル生成。
シリアル通信: SB/SCレジスタ、内部クロック8192Hz、8bit転送完了割り込み。
MBC2: 4bit内蔵RAM(512×4bit)、アドレスbit8でRAM/ROM切り替え。
MBC3: 7bit ROMバンク、4バンクRAM、RTCラッチ・秒カウンタ・停止機能。
MBC5: 9bit ROMバンク(512バンク)、16バンクRAM、バンク0選択可能。
全198テストパス（127→198、+71テスト）。

https://claude.ai/code/session_018nZatyWo4P5yjthN1Xmob4